### PR TITLE
Fix an issue where an exception would occur if init.rb works before running migration.

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -1,14 +1,13 @@
 class CustomMessageSettingsController < ApplicationController
   layout 'admin'
   before_action :require_admin, :set_custom_message_setting, :set_lang
-  require_sudo_mode :edit, :update
+  require_sudo_mode :edit, :update, :toggle_enabled
 
   def edit
   end
 
   def update
-    original_custom_messages = @setting.custom_messages
-    languages = (original_custom_messages.try(:keys) ? original_custom_messages.keys.map(&:to_s) : [])
+    languages = @setting.using_languages
 
     if setting_params.key?(:custom_messages) || params[:tab] == 'normal'
       @setting.update_with_custom_messages(setting_params[:custom_messages].try(:to_unsafe_h).try(:to_hash) || {}, @lang)
@@ -18,11 +17,20 @@ class CustomMessageSettingsController < ApplicationController
 
     if @setting.errors.blank?
       flash[:notice] = l(:notice_successful_update)
-      new_custom_messages = @setting.custom_messages
-      languages += new_custom_messages.keys.map(&:to_s) if new_custom_messages.try(:keys)
+      languages += @setting.using_languages
       CustomMessageSetting.reload_translations!(languages)
 
       redirect_to edit_custom_message_settings_path(tab: params[:tab], lang: @lang)
+    else
+      render :edit
+    end
+  end
+
+  def toggle_enabled
+    if @setting.toggle_enabled!
+      flash[:notice] =
+        @setting.enabled? ? l(:notice_enabled_customize) : l(:notice_disabled_customize)
+      redirect_to edit_custom_message_settings_path
     else
       render :edit
     end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -6,6 +6,10 @@ class CustomMessageSetting < Setting
     super('plugin_redmine_message_customize')
   end
 
+  def enabled?
+    !(self.value[:enabled] == 'false')
+  end
+
   def custom_messages(lang=nil)
     messages = self.value[:custom_messages] || self.value['custom_messages']
     if lang.present?
@@ -57,11 +61,35 @@ class CustomMessageSetting < Setting
     self.save
   end
 
+  def toggle_enabled!
+    customize_files = Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))
+    self.value = self.value.deep_merge({enabled: (!self.enabled?).to_s})
+
+    if result = self.save
+      if self.enabled?
+        I18n.load_path += customize_files
+      else
+        I18n.load_path -= customize_files
+      end
+      self.class.reload_translations!(self.using_languages)
+    end
+    result
+  end
+
+  def using_languages
+    messages = self.custom_messages
+    if messages.is_a?(Hash)
+      messages.keys.map(&:to_s)
+    else
+      [User.current.language]
+    end
+  end
+
   def self.available_messages(lang)
-    messages = I18n.backend.translations[self.find_language(lang).to_s.to_sym]
+    messages = I18n.backend.send(:translations)[self.find_language(lang).to_s.to_sym]
     if messages.nil?
       CustomMessageSetting.reload_translations!([lang])
-      messages = I18n.backend.translations[lang.to_s.to_sym] || {}
+      messages = I18n.backend.send(:translations)[lang.to_s.to_sym] || {}
     end
     self.flatten_hash(messages)
   end
@@ -92,7 +120,7 @@ class CustomMessageSetting < Setting
   end
 
   def self.reload_translations!(languages)
-    paths = ::I18n.load_path.select {|path| self.find_language(languages).include?(File.basename(path, '.*').to_s)}
+    paths = I18n.load_path.select {|path| self.find_language(languages).include?(File.basename(path, '.*').to_s)}
     I18n.backend.load_translations(paths)
   end
 

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -6,4 +6,8 @@
 <% if @setting.errors.any? %>
   <%= error_messages_for(@setting) %>
 <% end %>
+<p class='toggle-enable'>
+  <span class='icon icon-settings'></span>
+  <%= link_to (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize)), toggle_enabled_custom_message_settings_path, method: :post %>
+</p>
 <%= render_tabs (@setting.errors.any? ? [] : [{name: 'normal', partial: 'normal_tab', label: 'label_normal_tab'}]) + [{name: 'yaml', partial: 'yaml_tab', label: 'label_yaml_tab'}] %>

--- a/assets/stylesheets/custom_messages.css
+++ b/assets/stylesheets/custom_messages.css
@@ -35,3 +35,7 @@
 .select2-container--default .select2-results__option[aria-disabled=true] span {
   color: white;
 }
+
+p.toggle-enable {
+  text-align: right;
+}

--- a/config/locales/custom_messages/ar.rb
+++ b/config/locales/custom_messages/ar.rb
@@ -1,1 +1,1 @@
-{ ar: CustomMessageSetting.find_or_default.custom_messages('ar') }
+{ ar: CustomMessageSetting.find_or_default.custom_messages('ar', true) }

--- a/config/locales/custom_messages/az.rb
+++ b/config/locales/custom_messages/az.rb
@@ -1,1 +1,1 @@
-{ az: CustomMessageSetting.find_or_default.custom_messages('az') }
+{ az: CustomMessageSetting.find_or_default.custom_messages('az', true) }

--- a/config/locales/custom_messages/bg.rb
+++ b/config/locales/custom_messages/bg.rb
@@ -1,1 +1,1 @@
-{ bg: CustomMessageSetting.find_or_default.custom_messages('bg') }
+{ bg: CustomMessageSetting.find_or_default.custom_messages('bg', true) }

--- a/config/locales/custom_messages/bs.rb
+++ b/config/locales/custom_messages/bs.rb
@@ -1,1 +1,1 @@
-{ bs: CustomMessageSetting.find_or_default.custom_messages('bs') }
+{ bs: CustomMessageSetting.find_or_default.custom_messages('bs', true) }

--- a/config/locales/custom_messages/ca.rb
+++ b/config/locales/custom_messages/ca.rb
@@ -1,1 +1,1 @@
-{ ca: CustomMessageSetting.find_or_default.custom_messages('ca') }
+{ ca: CustomMessageSetting.find_or_default.custom_messages('ca', true) }

--- a/config/locales/custom_messages/cs.rb
+++ b/config/locales/custom_messages/cs.rb
@@ -1,1 +1,1 @@
-{ cs: CustomMessageSetting.find_or_default.custom_messages('cs') }
+{ cs: CustomMessageSetting.find_or_default.custom_messages('cs', true) }

--- a/config/locales/custom_messages/da.rb
+++ b/config/locales/custom_messages/da.rb
@@ -1,1 +1,1 @@
-{ da: CustomMessageSetting.find_or_default.custom_messages('da') }
+{ da: CustomMessageSetting.find_or_default.custom_messages('da', true) }

--- a/config/locales/custom_messages/de.rb
+++ b/config/locales/custom_messages/de.rb
@@ -1,1 +1,1 @@
-{ de: CustomMessageSetting.find_or_default.custom_messages('de') }
+{ de: CustomMessageSetting.find_or_default.custom_messages('de', true) }

--- a/config/locales/custom_messages/el.rb
+++ b/config/locales/custom_messages/el.rb
@@ -1,1 +1,1 @@
-{ el: CustomMessageSetting.find_or_default.custom_messages('el') }
+{ el: CustomMessageSetting.find_or_default.custom_messages('el', true) }

--- a/config/locales/custom_messages/en-GB.rb
+++ b/config/locales/custom_messages/en-GB.rb
@@ -1,1 +1,1 @@
-{ "en-GB": CustomMessageSetting.find_or_default.custom_messages('en-GB') }
+{ "en-GB": CustomMessageSetting.find_or_default.custom_messages('en-GB', true) }

--- a/config/locales/custom_messages/en.rb
+++ b/config/locales/custom_messages/en.rb
@@ -1,1 +1,1 @@
-{ en: CustomMessageSetting.find_or_default.custom_messages('en') }
+{ en: CustomMessageSetting.find_or_default.custom_messages('en', true) }

--- a/config/locales/custom_messages/es-PA.rb
+++ b/config/locales/custom_messages/es-PA.rb
@@ -1,1 +1,1 @@
-{ "es-PA": CustomMessageSetting.find_or_default.custom_messages('es-PA') }
+{ "es-PA": CustomMessageSetting.find_or_default.custom_messages('es-PA', true) }

--- a/config/locales/custom_messages/es.rb
+++ b/config/locales/custom_messages/es.rb
@@ -1,1 +1,1 @@
-{ es: CustomMessageSetting.find_or_default.custom_messages('es') }
+{ es: CustomMessageSetting.find_or_default.custom_messages('es', true) }

--- a/config/locales/custom_messages/et.rb
+++ b/config/locales/custom_messages/et.rb
@@ -1,1 +1,1 @@
-{ et: CustomMessageSetting.find_or_default.custom_messages('et') }
+{ et: CustomMessageSetting.find_or_default.custom_messages('et', true) }

--- a/config/locales/custom_messages/eu.rb
+++ b/config/locales/custom_messages/eu.rb
@@ -1,1 +1,1 @@
-{ eu: CustomMessageSetting.find_or_default.custom_messages('eu') }
+{ eu: CustomMessageSetting.find_or_default.custom_messages('eu', true) }

--- a/config/locales/custom_messages/fa.rb
+++ b/config/locales/custom_messages/fa.rb
@@ -1,1 +1,1 @@
-{ fa: CustomMessageSetting.find_or_default.custom_messages('fa') }
+{ fa: CustomMessageSetting.find_or_default.custom_messages('fa', true) }

--- a/config/locales/custom_messages/fi.rb
+++ b/config/locales/custom_messages/fi.rb
@@ -1,1 +1,1 @@
-{ fi: CustomMessageSetting.find_or_default.custom_messages('fi') }
+{ fi: CustomMessageSetting.find_or_default.custom_messages('fi', true) }

--- a/config/locales/custom_messages/fr.rb
+++ b/config/locales/custom_messages/fr.rb
@@ -1,1 +1,1 @@
-{ fr: CustomMessageSetting.find_or_default.custom_messages('fr') }
+{ fr: CustomMessageSetting.find_or_default.custom_messages('fr', true) }

--- a/config/locales/custom_messages/gl.rb
+++ b/config/locales/custom_messages/gl.rb
@@ -1,1 +1,1 @@
-{ gl: CustomMessageSetting.find_or_default.custom_messages('gl') }
+{ gl: CustomMessageSetting.find_or_default.custom_messages('gl', true) }

--- a/config/locales/custom_messages/he.rb
+++ b/config/locales/custom_messages/he.rb
@@ -1,1 +1,1 @@
-{ he: CustomMessageSetting.find_or_default.custom_messages('he') }
+{ he: CustomMessageSetting.find_or_default.custom_messages('he', true) }

--- a/config/locales/custom_messages/hr.rb
+++ b/config/locales/custom_messages/hr.rb
@@ -1,1 +1,1 @@
-{ hr: CustomMessageSetting.find_or_default.custom_messages('hr') }
+{ hr: CustomMessageSetting.find_or_default.custom_messages('hr', true) }

--- a/config/locales/custom_messages/hu.rb
+++ b/config/locales/custom_messages/hu.rb
@@ -1,1 +1,1 @@
-{ hu: CustomMessageSetting.find_or_default.custom_messages('hu') }
+{ hu: CustomMessageSetting.find_or_default.custom_messages('hu', true) }

--- a/config/locales/custom_messages/id.rb
+++ b/config/locales/custom_messages/id.rb
@@ -1,1 +1,1 @@
-{ id: CustomMessageSetting.find_or_default.custom_messages('id') }
+{ id: CustomMessageSetting.find_or_default.custom_messages('id', true) }

--- a/config/locales/custom_messages/it.rb
+++ b/config/locales/custom_messages/it.rb
@@ -1,1 +1,1 @@
-{ it: CustomMessageSetting.find_or_default.custom_messages('it') }
+{ it: CustomMessageSetting.find_or_default.custom_messages('it', true) }

--- a/config/locales/custom_messages/ja.rb
+++ b/config/locales/custom_messages/ja.rb
@@ -1,1 +1,1 @@
-{ ja: CustomMessageSetting.find_or_default.custom_messages('ja') }
+{ ja: CustomMessageSetting.find_or_default.custom_messages('ja', true) }

--- a/config/locales/custom_messages/ko.rb
+++ b/config/locales/custom_messages/ko.rb
@@ -1,1 +1,1 @@
-{ ko: CustomMessageSetting.find_or_default.custom_messages('ko') }
+{ ko: CustomMessageSetting.find_or_default.custom_messages('ko', true) }

--- a/config/locales/custom_messages/lt.rb
+++ b/config/locales/custom_messages/lt.rb
@@ -1,1 +1,1 @@
-{ lt: CustomMessageSetting.find_or_default.custom_messages('lt') }
+{ lt: CustomMessageSetting.find_or_default.custom_messages('lt', true) }

--- a/config/locales/custom_messages/lv.rb
+++ b/config/locales/custom_messages/lv.rb
@@ -1,1 +1,1 @@
-{ lv: CustomMessageSetting.find_or_default.custom_messages('lv') }
+{ lv: CustomMessageSetting.find_or_default.custom_messages('lv', true) }

--- a/config/locales/custom_messages/mk.rb
+++ b/config/locales/custom_messages/mk.rb
@@ -1,1 +1,1 @@
-{ mk: CustomMessageSetting.find_or_default.custom_messages('mk') }
+{ mk: CustomMessageSetting.find_or_default.custom_messages('mk', true) }

--- a/config/locales/custom_messages/mn.rb
+++ b/config/locales/custom_messages/mn.rb
@@ -1,1 +1,1 @@
-{ mn: CustomMessageSetting.find_or_default.custom_messages('mn') }
+{ mn: CustomMessageSetting.find_or_default.custom_messages('mn', true) }

--- a/config/locales/custom_messages/nl.rb
+++ b/config/locales/custom_messages/nl.rb
@@ -1,1 +1,1 @@
-{ nl: CustomMessageSetting.find_or_default.custom_messages('nl') }
+{ nl: CustomMessageSetting.find_or_default.custom_messages('nl', true) }

--- a/config/locales/custom_messages/no.rb
+++ b/config/locales/custom_messages/no.rb
@@ -1,1 +1,1 @@
-{ no: CustomMessageSetting.find_or_default.custom_messages('no') }
+{ no: CustomMessageSetting.find_or_default.custom_messages('no', true) }

--- a/config/locales/custom_messages/pl.rb
+++ b/config/locales/custom_messages/pl.rb
@@ -1,1 +1,1 @@
-{ pl: CustomMessageSetting.find_or_default.custom_messages('pl') }
+{ pl: CustomMessageSetting.find_or_default.custom_messages('pl', true) }

--- a/config/locales/custom_messages/pt-BR.rb
+++ b/config/locales/custom_messages/pt-BR.rb
@@ -1,1 +1,1 @@
-{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages('pt-BR') }
+{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages('pt-BR', true) }

--- a/config/locales/custom_messages/pt.rb
+++ b/config/locales/custom_messages/pt.rb
@@ -1,1 +1,1 @@
-{ pt: CustomMessageSetting.find_or_default.custom_messages('pt') }
+{ pt: CustomMessageSetting.find_or_default.custom_messages('pt', true) }

--- a/config/locales/custom_messages/ro.rb
+++ b/config/locales/custom_messages/ro.rb
@@ -1,1 +1,1 @@
-{ ro: CustomMessageSetting.find_or_default.custom_messages('ro') }
+{ ro: CustomMessageSetting.find_or_default.custom_messages('ro', true) }

--- a/config/locales/custom_messages/ru.rb
+++ b/config/locales/custom_messages/ru.rb
@@ -1,1 +1,1 @@
-{ ru: CustomMessageSetting.find_or_default.custom_messages('ru') }
+{ ru: CustomMessageSetting.find_or_default.custom_messages('ru', true) }

--- a/config/locales/custom_messages/sk.rb
+++ b/config/locales/custom_messages/sk.rb
@@ -1,1 +1,1 @@
-{ sk: CustomMessageSetting.find_or_default.custom_messages('sk') }
+{ sk: CustomMessageSetting.find_or_default.custom_messages('sk', true) }

--- a/config/locales/custom_messages/sl.rb
+++ b/config/locales/custom_messages/sl.rb
@@ -1,1 +1,1 @@
-{ sl: CustomMessageSetting.find_or_default.custom_messages('sl') }
+{ sl: CustomMessageSetting.find_or_default.custom_messages('sl', true) }

--- a/config/locales/custom_messages/sq.rb
+++ b/config/locales/custom_messages/sq.rb
@@ -1,1 +1,1 @@
-{ sq: CustomMessageSetting.find_or_default.custom_messages('sq') }
+{ sq: CustomMessageSetting.find_or_default.custom_messages('sq', true) }

--- a/config/locales/custom_messages/sr-YU.rb
+++ b/config/locales/custom_messages/sr-YU.rb
@@ -1,1 +1,1 @@
-{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages('sr-YU') }
+{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages('sr-YU', true) }

--- a/config/locales/custom_messages/sr.rb
+++ b/config/locales/custom_messages/sr.rb
@@ -1,1 +1,1 @@
-{ sr: CustomMessageSetting.find_or_default.custom_messages('sr') }
+{ sr: CustomMessageSetting.find_or_default.custom_messages('sr', true) }

--- a/config/locales/custom_messages/sv.rb
+++ b/config/locales/custom_messages/sv.rb
@@ -1,1 +1,1 @@
-{ sv: CustomMessageSetting.find_or_default.custom_messages('sv') }
+{ sv: CustomMessageSetting.find_or_default.custom_messages('sv', true) }

--- a/config/locales/custom_messages/th.rb
+++ b/config/locales/custom_messages/th.rb
@@ -1,1 +1,1 @@
-{ th: CustomMessageSetting.find_or_default.custom_messages('th') }
+{ th: CustomMessageSetting.find_or_default.custom_messages('th', true) }

--- a/config/locales/custom_messages/tr.rb
+++ b/config/locales/custom_messages/tr.rb
@@ -1,1 +1,1 @@
-{ tr: CustomMessageSetting.find_or_default.custom_messages('tr') }
+{ tr: CustomMessageSetting.find_or_default.custom_messages('tr', true) }

--- a/config/locales/custom_messages/uk.rb
+++ b/config/locales/custom_messages/uk.rb
@@ -1,1 +1,1 @@
-{ uk: CustomMessageSetting.find_or_default.custom_messages('uk') }
+{ uk: CustomMessageSetting.find_or_default.custom_messages('uk', true) }

--- a/config/locales/custom_messages/vi.rb
+++ b/config/locales/custom_messages/vi.rb
@@ -1,1 +1,1 @@
-{ vi: CustomMessageSetting.find_or_default.custom_messages('vi') }
+{ vi: CustomMessageSetting.find_or_default.custom_messages('vi', true) }

--- a/config/locales/custom_messages/zh-TW.rb
+++ b/config/locales/custom_messages/zh-TW.rb
@@ -1,1 +1,1 @@
-{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages('zh-TW') }
+{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages('zh-TW', true) }

--- a/config/locales/custom_messages/zh.rb
+++ b/config/locales/custom_messages/zh.rb
@@ -1,1 +1,1 @@
-{ zh: CustomMessageSetting.find_or_default.custom_messages('zh') }
+{ zh: CustomMessageSetting.find_or_default.custom_messages('zh', true) }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,5 +10,9 @@ en:
   error_unavailable_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
   error_invalid_yaml_format: The format of yaml is invalid.
+  notice_enabled_customize: Successful in enable messages customization.
+  notice_disabled_customize: Successful in disable messages customization.
   label_normal_tab: Normal mode
   label_yaml_tab: YAML mode
+  label_enable_customize: Enable customize
+  label_disable_customize: Disable customize

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,5 +10,9 @@ ja:
   error_unavailable_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。
   error_invalid_yaml_format: YAMLの形式が正しくありません。
+  notice_enabled_customize: メッセージのカスタマイズを有効に変更しました。
+  notice_disabled_customize: メッセージのカスタマイズを無効に変更しました。
   label_normal_tab: 通常モード
   label_yaml_tab: YAMLモード
+  label_enable_customize: カスタマイズを有効にする
+  label_disable_customize: カスタマイズを無効にする

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,5 +2,6 @@ Rails.application.routes.draw do
   resources :custom_message_settings, only: [] do
     get :edit, on: :collection
     post :update, on: :collection
+    post :toggle_enabled, on: :collection
   end
 end

--- a/init.rb
+++ b/init.rb
@@ -7,8 +7,6 @@ p = Redmine::Plugin.register :redmine_message_customize do
   requires_redmine version_or_higher: '3.2'
 end
 
-Rails.application.config.i18n.load_path += Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))
-
-class Redmine::I18n::Backend
-  public :translations
+if CustomMessageSetting.find_or_default.enabled?
+  Rails.application.config.i18n.load_path += Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))
 end

--- a/init.rb
+++ b/init.rb
@@ -7,6 +7,4 @@ p = Redmine::Plugin.register :redmine_message_customize do
   requires_redmine version_or_higher: '3.2'
 end
 
-if CustomMessageSetting.find_or_default.enabled?
-  Rails.application.config.i18n.load_path += Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))
-end
+Rails.application.config.i18n.load_path += Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))

--- a/test/fixtures/custom_message_settings.yml
+++ b/test/fixtures/custom_message_settings.yml
@@ -1,4 +1,7 @@
 one:
   id: 1
   name: plugin_redmine_message_customize
-  value: { custom_messages: { en: { label_home: 'Home1' }, ja: { label_home: 'Home2' }}}
+  value: {
+    custom_messages: { en: { label_home: 'Home1' }, ja: { label_home: 'Home2' }},
+    enabled: 'true'
+    }

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -7,6 +7,7 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
   def setup
     @request.session[:user_id] = 1 # admin
     CustomMessageSetting.reload_translations!('en')
+    I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
   # custom_message_settings/edit
@@ -23,8 +24,7 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
   def test_edit_except_admin_user
     @request.session[:user_id] = 2
     get :edit
-    assert_response 403
-    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
+    assert_redirected_to (/#{signin_path}/)
   end
 
   def test_update_with_custom_messages
@@ -52,11 +52,25 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
     assert_select 'h2', :text => l(:label_custom_messages)
     assert_select 'div#errorExplanation'
   end
-  def test_edit_except_admin_user
+  def test_update_except_admin_user
     @request.session[:user_id] = 2
     get :update, params: { settings: {'custom_messages'=>{'label_home' => 'Home3'}}, lang: 'en', tab: 'normal' }
 
-    assert_response 403
-    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
+    assert_redirected_to (/#{signin_path}/)
+  end
+
+  def test_toggle_enabled
+    patch :toggle_enabled
+    assert_redirected_to edit_custom_message_settings_path
+    assert_equal l(:notice_disabled_customize), flash[:notice]
+
+    patch :toggle_enabled
+    assert_equal l(:notice_enabled_customize), flash[:notice]
+  end
+  def test_toggle_enabled_except_admin_user
+    @request.session[:user_id] = 2
+    patch :toggle_enabled
+
+    assert_redirected_to (/#{signin_path}/)
   end
 end

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -24,7 +24,8 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
   def test_edit_except_admin_user
     @request.session[:user_id] = 2
     get :edit
-    assert_redirected_to (/#{signin_path}/)
+    assert_response 403
+    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
   end
 
   def test_update_with_custom_messages
@@ -56,7 +57,8 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
     @request.session[:user_id] = 2
     get :update, params: { settings: {'custom_messages'=>{'label_home' => 'Home3'}}, lang: 'en', tab: 'normal' }
 
-    assert_redirected_to (/#{signin_path}/)
+    assert_response 403
+    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
   end
 
   def test_toggle_enabled
@@ -71,6 +73,7 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
     @request.session[:user_id] = 2
     patch :toggle_enabled
 
-    assert_redirected_to (/#{signin_path}/)
+    assert_response 403
+    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
   end
 end

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -43,6 +43,17 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal ({}), @custom_message_setting.custom_messages('foo')
   end
 
+  def test_custom_messages_with_check_enabled
+    assert @custom_message_setting.enabled?
+    assert_equal ({'label_home' => 'Home1'}), @custom_message_setting.custom_messages('en', true)
+    assert_equal ({'label_home' => 'Home1'}), @custom_message_setting.custom_messages('en', false)
+
+    @custom_message_setting.toggle_enabled!
+    assert_not @custom_message_setting.enabled?
+    assert_equal ({}), @custom_message_setting.custom_messages('en', true)
+    assert_equal ({'label_home' => 'Home1'}), @custom_message_setting.custom_messages('en', false)
+  end
+
   def test_custom_messages_to_yaml
     assert_equal "---\nen:\n  label_home: Home1\nja:\n  label_home: Home2\n", @custom_message_setting.custom_messages_to_yaml
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -6,6 +6,8 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
 
   def setup
     @custom_message_setting = CustomMessageSetting.find(1)
+    CustomMessageSetting.reload_translations!('en')
+    I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
   def test_validate_with_not_available_keys_should_return_false
@@ -22,6 +24,17 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
 
   def test_find_or_default
     assert_equal @custom_message_setting, CustomMessageSetting.find_or_default
+  end
+
+  def test_enabled?
+    @custom_message_setting.value = { enabled: 'true' }
+    assert @custom_message_setting.enabled?
+
+    @custom_message_setting.value = { enabled: 'false' }
+    assert_not @custom_message_setting.enabled?
+
+    @custom_message_setting.value = { enabled: nil }
+    assert @custom_message_setting.enabled?
   end
 
   def test_custom_messages
@@ -62,6 +75,23 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal "(<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1", @custom_message_setting.errors[:base].first
   end
 
+  def test_toggle_enabled!
+    assert @custom_message_setting.enabled?
+    assert_equal 'Home1', l(:label_home)
+
+    @custom_message_setting.toggle_enabled!
+    assert_not @custom_message_setting.enabled?
+    assert_equal 'Home', l(:label_home)
+
+    @custom_message_setting.toggle_enabled!
+    assert @custom_message_setting.enabled?
+    assert_equal 'Home1', l(:label_home)
+  end
+
+  def test_using_languages
+    assert_equal ['en', 'ja'], @custom_message_setting.using_languages
+  end
+
   def test_available_messages_should_flatten_translations
     flatten_hash = CustomMessageSetting.available_messages('en')
     assert_equal 'am', flatten_hash[:'time.am']
@@ -82,8 +112,8 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   end
 
   def test_reload_translations!
-    assert_nil I18n.backend.translations[:fr]
+    assert_nil I18n.backend.send(:translations)[:fr]
     CustomMessageSetting.reload_translations!(['fr'])
-    assert_not_nil I18n.backend.translations[:fr]
+    assert_not_nil I18n.backend.send(:translations)[:fr]
   end
 end


### PR DESCRIPTION
Execution of `bundle exec rake db:create` or `bundle exec rake db:migrate` raises an exception.
Related to https://github.com/ishikawa999/redmine_message_customize/pull/4.

The cause of this problem is that `CustomMessageSetting.find_or_default.enabled?` is also executed before migration is executed.
This pull request has changed the process to switch message customization to disabled/enabled.