### PR TITLE
Change conversion method of list format string #8

### DIFF
--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -122,6 +122,14 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal ({'time' => {'am' => 'foo'}}), nested_hash
   end
 
+  def test_flatten_hash_with_list_value_should_convert_string_to_array
+    nested_hash = CustomMessageSetting.nested_hash({'date.order' => "[\":year\", \":month\", \":day\"]"})
+    assert_equal ({'date' => {'order' => [':year', ':month', ':day']}}), nested_hash
+
+    nested_hash = CustomMessageSetting.nested_hash({'date.order' => "[:year, :month, :day]"})
+    assert_equal ({'date' => {'order' => [':year', ':month', ':day']}}), nested_hash
+  end
+
   def test_reload_translations!
     assert_nil I18n.backend.send(:translations)[:fr]
     CustomMessageSetting.reload_translations!(['fr'])


### PR DESCRIPTION
related to #8 .

In order to solve the problem of #8 , when a Psych :: SyntaxError occurs, it is converted in another way.
At the same time, I did code clean up for CustomMessageSetting.nested_hash.