### PR TITLE
Add default messages page

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -1,9 +1,13 @@
 class CustomMessageSettingsController < ApplicationController
   layout 'admin'
   before_action :require_admin, :set_custom_message_setting, :set_lang
-  require_sudo_mode :edit, :update, :toggle_enabled
+  require_sudo_mode :edit, :update, :toggle_enabled, :default_messages
 
   def edit
+  end
+
+  def default_messages
+    @file_path = Rails.root.join('config', 'locales', "#{@lang}.yml")
   end
 
   def update

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -19,4 +19,11 @@ module CustomMessageSettingsHelper
     end
     content
   end
+
+  def open_default_messages_window_link(lang)
+    link_to l(:label_default_messages),
+            default_messages_custom_message_settings_path(lang: lang),
+            class: 'icon icon-file text-plain',
+            onclick: "window.open(this.href,'#{l(:label_default_messages)}', 'height=800, width=500');return false;"
+  end
 end

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -24,7 +24,7 @@ module CustomMessageSettingsHelper
     link_to l(:label_default_messages),
             default_messages_custom_message_settings_path(lang: lang),
             class: 'icon icon-file text-plain',
-            onclick: "window.open(this.href,'default-messages', 'height=800, width=500');return false;",
+            onclick: "window.open(this.href,'redmine_message_customize_plugin-default_messages', 'height=800, width=500');return false;",
             id: 'default-messages-link'
   end
 end

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -24,6 +24,7 @@ module CustomMessageSettingsHelper
     link_to l(:label_default_messages),
             default_messages_custom_message_settings_path(lang: lang),
             class: 'icon icon-file text-plain',
-            onclick: "window.open(this.href,'#{l(:label_default_messages)}', 'height=800, width=500');return false;"
+            onclick: "window.open(this.href,'#{l(:label_default_messages)}', 'height=800, width=500');return false;",
+            id: 'default-messages-link'
   end
 end

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -24,7 +24,7 @@ module CustomMessageSettingsHelper
     link_to l(:label_default_messages),
             default_messages_custom_message_settings_path(lang: lang),
             class: 'icon icon-file text-plain',
-            onclick: "window.open(this.href,'#{l(:label_default_messages)}', 'height=800, width=500');return false;",
+            onclick: "window.open(this.href,'default-messages', 'height=800, width=500');return false;",
             id: 'default-messages-link'
   end
 end

--- a/app/views/custom_message_settings/_yaml_tab.html.erb
+++ b/app/views/custom_message_settings/_yaml_tab.html.erb
@@ -1,10 +1,13 @@
 <%= form_tag custom_message_settings_path, method: :post do %>
   <%= hidden_field_tag :tab, 'yaml' %>
   <div class='help-message wiki'>
-    <p><%= l(:text_help_for_input_format) %></p>
+    <p>
+      <%= l(:text_help_for_input_format) %><br>
+      <%= l(:text_for_your_reference, open_default_messages_window_link(@lang)).html_safe %>
+    </p>
     <p><%= l(:text_placeholder_template_case) %></p>
     <pre><%= l(:text_placeholder_yaml_template) %></pre>
   </div>
-  <%= text_area_tag 'settings[custom_messages_yaml]', @setting.custom_messages_to_yaml, rows: '20', style: 'width: 100%', placeholder: l(:text_placeholder_yaml_template) %>
+  <%= text_area_tag 'settings[custom_messages_yaml]', @setting.custom_messages_to_yaml, rows: '30', style: 'width: 100%', placeholder: l(:text_placeholder_yaml_template) %>
   <%= submit_tag l(:button_save) %>
 <% end %>

--- a/app/views/custom_message_settings/default_messages.html.erb
+++ b/app/views/custom_message_settings/default_messages.html.erb
@@ -1,0 +1,27 @@
+<%= stylesheet_link_tag('default_messages', plugin: 'redmine_message_customize') %>
+<h2><%= l(:label_default_messages) %>(<%= "config/locales/#{@lang}.yml" %>)</h2>
+
+<label><%= l(:field_language) %>: </label>
+<%= select_tag 'lang', options_for_select(languages_options, @lang), onchange: "window.location.replace('#{default_messages_custom_message_settings_path}?lang=' + this.value)" %>
+<%= link_to l(:button_back), edit_custom_message_settings_path(lang: @lang) %>
+
+<% if @file_path.exist? %>
+  <div class="autoscroll">
+    <table class="filecontent syntaxhl">
+      <tbody>
+      <% line_num = 1 %>
+      <% syntax_highlight_lines(@file_path.basename.to_s, Redmine::CodesetUtil.to_utf8_by_setting(File.open(@file_path).read)).each do |line| %>
+        <tr id="L<%= line_num %>">
+          <th class="line-num">
+            <a href="#L<%= line_num %>"><%= line_num %></a>
+          </th>
+          <td class="line-code">
+            <pre><%= line.html_safe %></pre>
+          </td>
+        </tr>
+        <% line_num += 1 %>
+      <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/custom_message_settings/default_messages.html.erb
+++ b/app/views/custom_message_settings/default_messages.html.erb
@@ -3,7 +3,6 @@
 
 <label><%= l(:field_language) %>: </label>
 <%= select_tag 'lang', options_for_select(languages_options, @lang), onchange: "window.location.replace('#{default_messages_custom_message_settings_path}?lang=' + this.value)" %>
-<%= link_to l(:button_back), edit_custom_message_settings_path(lang: @lang) %>
 
 <% if @file_path.exist? %>
   <div class="autoscroll">

--- a/app/views/custom_message_settings/default_messages.html.erb
+++ b/app/views/custom_message_settings/default_messages.html.erb
@@ -9,7 +9,7 @@
     <table class="filecontent syntaxhl">
       <tbody>
       <% line_num = 1 %>
-      <% syntax_highlight_lines(@file_path.basename.to_s, Redmine::CodesetUtil.to_utf8_by_setting(File.open(@file_path).read)).each do |line| %>
+      <% syntax_highlight_lines(@file_path.basename.to_s, Redmine::CodesetUtil.to_utf8_by_setting(File.read(@file_path))).each do |line| %>
         <tr id="L<%= line_num %>">
           <th class="line-num">
             <a href="#L<%= line_num %>"><%= line_num %></a>

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -7,7 +7,7 @@
   <%= error_messages_for(@setting) %>
 <% end %>
 <p class='toggle-enable'>
-  <span class='icon icon-settings'></span>
-  <%= link_to (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize)), toggle_enabled_custom_message_settings_path, method: :post %>
+  <%= link_to (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize)), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon icon-settings' %> /
+  <%= open_default_messages_window_link(@lang) %>
 </p>
 <%= render_tabs (@setting.errors.any? ? [] : [{name: 'normal', partial: 'normal_tab', label: 'label_normal_tab'}]) + [{name: 'yaml', partial: 'yaml_tab', label: 'label_yaml_tab'}] %>

--- a/app/views/custom_message_settings/edit.js.erb
+++ b/app/views/custom_message_settings/edit.js.erb
@@ -1,2 +1,3 @@
 $('#edit-custom-messages').html("<%= j (render 'custom_message_settings/messages', lang: @lang) %>");
+$('#default-messages-link').replaceWith('<%= open_default_messages_window_link(@lang) %>')
 $('#ajax-indicator').hide();

--- a/assets/stylesheets/default_messages.css
+++ b/assets/stylesheets/default_messages.css
@@ -1,0 +1,71 @@
+/* Same style as part of scm.yml */
+table.filecontent {
+  border: 1px solid #e2e2e2;
+  border-collapse: collapse;
+  width: 98%;
+  background-color: #fafafa;
+}
+
+table.filecontent tbody {
+  font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;
+  font-size: 12px;
+}
+
+table.filecontent th {
+  border: 1px solid #e2e2e2;
+  background-color: #eee;
+}
+
+table.filecontent th.filename {
+  background-color: #e4e4d4;
+  text-align: left;
+  padding: 5px;
+}
+
+table.filecontent tr.spacing th {
+  text-align: center;
+}
+
+table.filecontent tr.spacing td {
+  height: 0.4em;
+  background: #EAF2F5;
+}
+
+table.filecontent th.line-num {
+  border: 1px solid #e2e2e2;
+  text-align: right;
+  width: 2%;
+  padding: 0 3px 0 0;
+  color: #999;
+  user-select: none;
+  -moz-user-select: none;
+  -o-user-select: none;
+  -ms-user-select: none;
+  -webkit-user-select: none;
+  font-weight: normal;
+}
+
+table.filecontent th.line-num a {
+  text-decoration: none;
+  color: inherit;
+}
+
+table.filecontent td.line-code {
+  padding: 0 0 0 4px;
+}
+
+table.filecontent td.line-code pre {
+  margin: 0px;
+  white-space: pre-wrap;
+  font-family: Consolas, Menlo, "Liberation Mono", Courier, monospace;
+  font-size: 12px;
+}
+
+table.filecontent tr:target th.line-num {
+  background-color: #E0E0E0;
+  color: #777;
+}
+
+table.filecontent tr:target td.line-code {
+  background-color: #DDEEFF;
+}

--- a/assets/stylesheets/default_messages.css
+++ b/assets/stylesheets/default_messages.css
@@ -69,3 +69,14 @@ table.filecontent tr:target th.line-num {
 table.filecontent tr:target td.line-code {
   background-color: #DDEEFF;
 }
+
+/* Hide unnecessary headers etc */
+body.action-default_messages #sidebar,
+body.action-default_messages #header,
+body.action-default_messages #top-menu {
+  display: none;
+}
+
+body.action-default_messages #main {
+  padding: 0px;
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -7,6 +7,7 @@ en:
         label_home: 'TOP'
   text_placeholder_choose_key: Please select the message you want to change.
   text_description_of_search_box: You can enter search terms in the search box to narrow down the results.
+  text_for_your_reference: "If you do not know how to write, please refer to %{value}."
   error_unavailable_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
   error_invalid_yaml_format: The format of yaml is invalid.
@@ -16,3 +17,4 @@ en:
   label_yaml_tab: YAML mode
   label_enable_customize: Enable customize
   label_disable_customize: Disable customize
+  label_default_messages: Default messages

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -7,6 +7,7 @@ ja:
         label_home: 'TOP'
   text_placeholder_choose_key: 変更したい文言を選択してください。
   text_description_of_search_box: 検索ボックスにキーワードを入力することで、選択肢を絞り込むことが出来ます。
+  text_for_your_reference: "もし書き方がわからない場合は、%{value}が参考になるはずです。"
   error_unavailable_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。
   error_invalid_yaml_format: YAMLの形式が正しくありません。
@@ -16,3 +17,4 @@ ja:
   label_yaml_tab: YAMLモード
   label_enable_customize: カスタマイズを有効にする
   label_disable_customize: カスタマイズを無効にする
+  label_default_messages: デフォルトのメッセージ

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Rails.application.routes.draw do
   resources :custom_message_settings, only: [] do
-    get :edit, on: :collection
-    post :update, on: :collection
-    post :toggle_enabled, on: :collection
+    get  :edit,             on: :collection
+    get  :default_messages, on: :collection
+    post :update,           on: :collection
+    post :toggle_enabled,   on: :collection
   end
 end

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -28,6 +28,22 @@ class CustomMessageSettingsControllerTest < Redmine::ControllerTest
     assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
   end
 
+  def test_default_messages
+    get :default_messages, params: {lang: 'ja'}
+    assert_response :success
+
+    assert_select 'h2', :text => "#{l(:label_default_messages)}(config/locales/ja.yml)"
+    assert_select 'div.autoscroll' do
+      assert_select 'table.filecontent.syntaxhl'
+    end
+  end
+  def test_default_messages_except_admin_user
+    @request.session[:user_id] = 2
+    get :default_messages
+    assert_response 403
+    assert_select 'p#errorExplanation', text: 'You are not authorized to access this page.'
+  end
+
   def test_update_with_custom_messages
     assert_equal 'Home1', l(:label_home)
 


### PR DESCRIPTION
Add the ability to check config/locales/*.yml from admin view.
I would like a review.

<img width="719" alt="ScreenShot-2019-06-11-16 17 12" src="https://user-images.githubusercontent.com/14245262/59251309-7d668600-8c64-11e9-825c-a1c8e4bb15be.png">

Clicking the "Default messages" link will open a window.
<img width="719" alt="ScreenShot-2019-06-11-16 17 33" src="https://user-images.githubusercontent.com/14245262/59251310-7d668600-8c64-11e9-83e8-0bce26447352.png">
