### PR TITLE
Fix "Infinite loop occurs in the process of calling I18n.available_locales"

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -18,7 +18,7 @@ class CustomMessageSettingsController < ApplicationController
     if @setting.errors.blank?
       flash[:notice] = l(:notice_successful_update)
       languages += @setting.using_languages
-      CustomMessageSetting.reload_translations!(languages)
+      MessageCustomize::Locale.reload!(languages)
 
       redirect_to edit_custom_message_settings_path(tab: params[:tab], lang: @lang)
     else
@@ -46,6 +46,6 @@ class CustomMessageSettingsController < ApplicationController
   end
 
   def set_lang
-    @lang = CustomMessageSetting.find_language(params[:lang].presence || User.current.language.presence || 'en')
+    @lang = MessageCustomize::Locale.find_language(params[:lang].presence || User.current.language.presence || 'en')
   end
 end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -84,10 +84,11 @@ class CustomMessageSetting < Setting
   end
 
   def self.available_messages(lang)
-    messages = I18n.backend.send(:translations)[lang.to_s.to_sym]
+    lang = :"#{lang}"
+    messages = I18n.backend.send(:translations)[lang]
     if messages.nil?
       MessageCustomize::Locale.reload!([lang])
-      messages = I18n.backend.send(:translations)[lang.to_s.to_sym] || {}
+      messages = I18n.backend.send(:translations)[lang] || {}
     end
     self.flatten_hash(messages)
   end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -87,7 +87,7 @@ class CustomMessageSetting < Setting
     lang = :"#{lang}"
     messages = I18n.backend.send(:translations)[lang]
     if messages.nil?
-      MessageCustomize::Locale.reload!([lang])
+      MessageCustomize::Locale.reload!(lang)
       messages = I18n.backend.send(:translations)[lang] || {}
     end
     self.flatten_hash(messages)

--- a/init.rb
+++ b/init.rb
@@ -1,3 +1,5 @@
+require_dependency 'message_customize/locale'
+
 p = Redmine::Plugin.register :redmine_message_customize do
   name 'Redmine customize messages plugin'
   description 'This is a plugin that allows messages in Redmine to be overwritten from the admin view'

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -13,8 +13,10 @@ module MessageCustomize
       end
 
       def find_language(language=nil)
+        return nil if language.nil?
+
         if language.is_a?(Array)
-          language.select{|l| self.available_locales.include?(:"#{l}")}.map(&:to_s).compact
+          language.select{|l| self.find_language(:"#{l}").present?}.map(&:to_s).uniq
         elsif language.present? && self.available_locales.include?(:"#{language}")
           language.to_s
         end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -3,7 +3,7 @@ module MessageCustomize
 
     class << self
       def available_locales
-        I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
+        @locales ||= I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
       end
 
       def reload!(*languages)

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -13,8 +13,8 @@ module MessageCustomize
 
       def find_language(language=nil)
         if language.is_a?(Array)
-          language.select{|l| self.available_locales.include?(l.to_s.to_sym)}.map(&:to_s).compact
-        elsif language.present? && self.available_locales.include?(language.to_s.to_sym)
+          language.select{|l| self.available_locales.include?(:"#{l}")}.map(&:to_s).compact
+        elsif language.present? && self.available_locales.include?(:"#{language}")
           language.to_s
         end
       end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -16,7 +16,7 @@ module MessageCustomize
         return nil if language.nil?
 
         if language.is_a?(Array)
-          language.select{|l| self.find_language(:"#{l}").present?}.map(&:to_s).uniq
+          language.select{|l| self.find_language(l).present?}.map(&:to_s).uniq
         elsif language.present? && self.available_locales.include?(:"#{language}")
           language.to_s
         end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -6,8 +6,9 @@ module MessageCustomize
         I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
       end
 
-      def reload!(languages)
-        paths = I18n.load_path.select {|path| self.find_language(languages).include?(File.basename(path, '.*').to_s)}
+      def reload!(*languages)
+        available_languages = self.find_language(languages.flatten)
+        paths = I18n.load_path.select {|path| available_languages.include?(File.basename(path, '.*').to_s)}
         I18n.backend.load_translations(paths)
       end
 

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -1,0 +1,23 @@
+module MessageCustomize
+  module Locale
+
+    class << self
+      def available_locales
+        I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
+      end
+
+      def reload!(languages)
+        paths = I18n.load_path.select {|path| self.find_language(languages).include?(File.basename(path, '.*').to_s)}
+        I18n.backend.load_translations(paths)
+      end
+
+      def find_language(language=nil)
+        if language.is_a?(Array)
+          language.select{|l| self.available_locales.include?(l.to_s.to_sym)}.map(&:to_s).compact
+        elsif language.present? && self.available_locales.include?(language.to_s.to_sym)
+          language.to_s
+        end
+      end
+    end
+  end
+end

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -1,12 +1,12 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class CustomMessageSettingsControllerTest < Redmine::ControllerTest
-  fixtures :custom_message_settings
+  fixtures :custom_message_settings, :users
   include Redmine::I18n
 
   def setup
     @request.session[:user_id] = 1 # admin
-    CustomMessageSetting.reload_translations!('en')
+    MessageCustomize::Locale.reload!('en')
     I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -6,7 +6,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
 
   def setup
     @custom_message_setting = CustomMessageSetting.find(1)
-    CustomMessageSetting.reload_translations!('en')
+    MessageCustomize::Locale.reload!('en')
     I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
@@ -120,11 +120,5 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   def test_flatten_hash_should_return_nest_hash
     nested_hash = CustomMessageSetting.nested_hash({:'time.am' => 'foo'})
     assert_equal ({'time' => {'am' => 'foo'}}), nested_hash
-  end
-
-  def test_reload_translations!
-    assert_nil I18n.backend.send(:translations)[:fr]
-    CustomMessageSetting.reload_translations!(['fr'])
-    assert_not_nil I18n.backend.send(:translations)[:fr]
   end
 end

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -10,7 +10,7 @@ class LocaleTest < ActiveSupport::TestCase
     setting.save
 
     assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
-    MessageCustomize::Locale.reload!(['en'])
+    MessageCustomize::Locale.reload!('en')
     assert_equal 'Changed home', I18n.backend.send(:translations)[:en][:label_home]
   end
 

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -1,0 +1,23 @@
+require File.expand_path('../../../../test_helper', __FILE__)
+
+class LocaleTest < ActiveSupport::TestCase
+  fixtures :custom_message_settings
+  include Redmine::I18n
+
+  def test_reload!
+    setting = CustomMessageSetting.find(1)
+    setting.value = {custom_messages: { 'en' => { 'label_home' => 'Changed home' }}}
+    setting.save
+
+    assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
+    MessageCustomize::Locale.reload!(['en'])
+    assert_equal 'Changed home', I18n.backend.send(:translations)[:en][:label_home]
+  end
+
+  # If this test fails:
+  #  Check if you need to change plugins/redmine_message_customize/config/locales/custom_messages.
+  def test_available_locales
+    locales = %w[ar az bg bs ca cs da de el en en-GB es es-PA et eu fa fi fr gl he hr hu id it ja ko lt lv mk mn nl no pl pt pt-BR ro ru sk sl sq sr sr-YU sv th tr uk vi zh zh-TW]
+    assert_equal locales.uniq.sort.map(&:to_sym), MessageCustomize::Locale.available_locales
+  end
+end


### PR DESCRIPTION
Fix #12 

Changes:
* Stop using I18n.backend.available_locales
* Add method to MessageCustomize::Locale instead of I18n.backend.available_locales
* Move locales related processing from custom_message_setting to MessageCustomize::Locale