### PR TITLE
Add a message when ActiveRecord::ValueTooLong occurs

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -28,6 +28,8 @@ class CustomMessageSettingsController < ApplicationController
     else
       render :edit
     end
+  rescue ActiveRecord::ValueTooLong
+    render_error l(:error_value_too_long)
   end
 
   def toggle_enabled

--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -29,12 +29,9 @@ class CustomMessageSettingsController < ApplicationController
       render :edit
     end
 
-  rescue => e
-    if e.is_a?(ActiveRecord::StatementInvalid) || (Object.const_defined?('ActiveRecord::ValueTooLong') && e.is_a?(ActiveRecord::ValueTooLong))
-      render_error l(:error_value_too_long)
-    else
-      raise e
-    end
+  # Catch an exception that occurs when the value field capacity is exceeded (ActiveRecord::ValueTooLong)
+  rescue ActiveRecord::StatementInvalid
+    render_error l(:error_value_too_long)
   end
 
   def toggle_enabled

--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -28,8 +28,13 @@ class CustomMessageSettingsController < ApplicationController
     else
       render :edit
     end
-  rescue ActiveRecord::ValueTooLong
-    render_error l(:error_value_too_long)
+
+  rescue => e
+    if e.is_a?(ActiveRecord::StatementInvalid) || (Object.const_defined?('ActiveRecord::ValueTooLong') && e.is_a?(ActiveRecord::ValueTooLong))
+      render_error l(:error_value_too_long)
+    else
+      raise e
+    end
   end
 
   def toggle_enabled

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -11,6 +11,7 @@ en:
   error_unavailable_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
   error_invalid_yaml_format: The format of yaml is invalid.
+  error_value_too_long: "Could not save because there are too many custom messages. Please reduce the amount of messages custom messages."
   notice_enabled_customize: Successful in enable messages customization.
   notice_disabled_customize: Successful in disable messages customization.
   label_normal_tab: Normal mode

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -11,6 +11,7 @@ ja:
   error_unavailable_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。
   error_invalid_yaml_format: YAMLの形式が正しくありません。
+  error_value_too_long: "カスタマイズするメッセージが多すぎるため保存できませんでした。カスタマイズするメッセージを減らしてください。"
   notice_enabled_customize: メッセージのカスタマイズを有効に変更しました。
   notice_disabled_customize: メッセージのカスタマイズを無効に変更しました。
   label_normal_tab: 通常モード


### PR DESCRIPTION
#15

When ActiveRecord::ValueTooLong occurs, display more concretely error message.