### PR TITLE
Check available_keys of custom_message_keys_are_available by language

### DIFF
--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -123,12 +123,12 @@ class CustomMessageSetting < Setting
   def custom_message_keys_are_available
     return false if !value[:custom_messages].is_a?(Hash) || errors.present?
 
-    custom_messages_hash = {}
-    custom_messages.values.compact.each do |val|
-      custom_messages_hash = self.class.flatten_hash(custom_messages_hash.merge(val)) if val.is_a?(Hash)
+    unavailable_keys = []
+    custom_messages.each do |lang, val|
+      available_keys = self.class.flatten_hash(self.class.available_messages(lang)).keys
+      unavailable_keys += self.class.flatten_hash(val).keys.reject{|k| available_keys.include?(:"#{k}")}.map{|k| "#{lang}.#{k}"}
     end
-    available_keys = self.class.flatten_hash(self.class.available_messages('en')).keys
-    unavailable_keys = custom_messages_hash.keys.reject{|k| available_keys.include?(k.to_sym)}
+
     if unavailable_keys.present?
       self.errors.add(:base, l(:error_unavailable_keys) + " keys: [#{unavailable_keys.join(', ')}]")
       false

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -13,7 +13,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   def test_validate_with_not_available_keys_should_return_false
     @custom_message_setting.value = { custom_messages: { 'en' => {'foobar' => 'foobar' }} }
     assert_not @custom_message_setting.save
-    assert_equal "#{l(:error_unavailable_keys)} keys: [foobar]", @custom_message_setting.errors[:base].first
+    assert_equal "#{l(:error_unavailable_keys)} keys: [en.foobar]", @custom_message_setting.errors[:base].first
   end
 
   def test_validate_with_not_available_languages_should_return_false


### PR DESCRIPTION
Fix #17

en.ymlに同じキーがあるか？というバリデーションをしていましたが、
en.ymlには含まれていないがja.ymlには含まれているようなキーがいくつかありました。

各言語に応じてunavailable_keysを決めるように修正しました。