### PR TITLE
Move CustomMessageSetting.available_messages to MessageCustomize::Locale

### DIFF
--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -1,7 +1,8 @@
 module CustomMessageSettingsHelper
   def available_message_options(setting, lang)
     options = [['', '']] +
-                CustomMessageSetting.available_messages(lang).map{|k, v| ["#{k}: #{v}", k]}
+                CustomMessageSetting.flatten_hash(MessageCustomize::Locale.available_messages(lang))
+                .map{|k, v| ["#{k}: #{v}", k]}
 
     options_for_select(options, disabled: setting.custom_messages_to_flatten_hash(lang).keys)
   end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -83,16 +83,6 @@ class CustomMessageSetting < Setting
     end
   end
 
-  def self.available_messages(lang)
-    lang = :"#{lang}"
-    messages = I18n.backend.send(:translations)[lang]
-    if messages.nil?
-      MessageCustomize::Locale.reload!(lang)
-      messages = I18n.backend.send(:translations)[lang] || {}
-    end
-    self.flatten_hash(messages)
-  end
-
   # { date: { formats: { defaults: '%m/%d/%Y'}}} to {'date.formats.defaults' => '%m/%d/%Y'}
   def self.flatten_hash(hash=nil)
     hash = self.to_hash unless hash
@@ -127,7 +117,7 @@ class CustomMessageSetting < Setting
     custom_messages.values.compact.each do |val|
       custom_messages_hash = self.class.flatten_hash(custom_messages_hash.merge(val)) if val.is_a?(Hash)
     end
-    available_keys = self.class.flatten_hash(self.class.available_messages('en')).keys
+    available_keys = self.class.flatten_hash(MessageCustomize::Locale.available_messages('en')).keys
     unavailable_keys = custom_messages_hash.keys.reject{|k| available_keys.include?(k.to_sym)}
     if unavailable_keys.present?
       self.errors.add(:base, l(:error_unavailable_keys) + " keys: [#{unavailable_keys.join(', ')}]")

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -26,17 +26,8 @@ module MessageCustomize
 
       def available_messages(lang)
         lang = :"#{lang}"
-        if @available_messages[lang].present?
-          @available_messages[lang]
-        else
-          messages = I18n.backend.send(:translations)[lang]
-          if messages.nil?
-            MessageCustomize::Locale.reload!(lang)
-            messages = I18n.backend.send(:translations)[lang] || {}
-          end
-          @available_messages[lang] = messages
-          messages
-        end
+        self.reload!(lang) if @available_messages[lang].blank?
+        @available_messages[lang] || {}
       end
     end
   end

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -103,15 +103,6 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal ['en', 'ja'], @custom_message_setting.using_languages
   end
 
-  def test_available_messages_should_flatten_translations
-    flatten_hash = CustomMessageSetting.available_messages('en')
-    assert_equal 'am', flatten_hash[:'time.am']
-
-    # Language 'ar' not loaded
-    flatten_hash = CustomMessageSetting.available_messages('ar')
-    assert_equal "صباحا", flatten_hash[:'time.am']
-  end
-
   def test_flatten_hash_should_return_hash_with_flat_keys
     flatten_hash = CustomMessageSetting.flatten_hash({time: {am: 'foo'}})
     assert_equal ({:'time.am' => 'foo'}), flatten_hash

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -4,7 +4,15 @@ class LocaleTest < ActiveSupport::TestCase
   fixtures :custom_message_settings
   include Redmine::I18n
 
+    def setup
+      MessageCustomize::Locale.reload!('en')
+      I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
+    end
+
   def test_reload!
+    # Reset @available_messages
+    MessageCustomize::Locale.instance_variable_set(:@available_messages, {})
+
     setting = CustomMessageSetting.find(1)
     setting.value = {custom_messages: { 'en' => { 'label_home' => 'Changed home' }}}
     setting.save
@@ -12,6 +20,7 @@ class LocaleTest < ActiveSupport::TestCase
     assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
     MessageCustomize::Locale.reload!('en')
     assert_equal 'Changed home', I18n.backend.send(:translations)[:en][:label_home]
+    assert_equal [:en], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys
   end
 
   # If this test fails:
@@ -19,5 +28,19 @@ class LocaleTest < ActiveSupport::TestCase
   def test_available_locales
     locales = %w[ar az bg bs ca cs da de el en en-GB es es-PA et eu fa fi fr gl he hr hu id it ja ko lt lv mk mn nl no pl pt pt-BR ro ru sk sl sq sr sr-YU sv th tr uk vi zh zh-TW]
     assert_equal locales.uniq.sort.map(&:to_sym), MessageCustomize::Locale.available_locales
+  end
+
+  def test_available_messages_should_return_translations
+    # Reset @available_messages
+    MessageCustomize::Locale.instance_variable_set(:@available_messages, {})
+
+    en_available_messages = MessageCustomize::Locale.available_messages('en')
+    assert_equal 'am', en_available_messages[:time][:am]
+    assert_equal [:en], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys
+
+    # Language 'ar' not loaded
+    ar_available_messages = MessageCustomize::Locale.available_messages('ar')
+    assert_equal "صباحا", ar_available_messages[:time][:am]
+    assert_equal [:en, :ar], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys
   end
 end


### PR DESCRIPTION
#19 

flatten_hashメソッドを使っている以外はI18n絡みの処理で、CustomMessageSettingの情報を使うわけでもないためMessageCustomize::Localeにメソッドを移動します。

また、available_messagesメソッドは保存時(バリデーション)、画面の表示(options)のときに毎回呼び出されるため、@available_messagesに入れておくように変更しました。

確認をお願いいたします。