### PR TITLE
Change the key with non-string value to be not customizable

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -45,6 +45,7 @@ class CustomMessageSettingsController < ApplicationController
   end
 
   private
+
   def set_custom_message_setting
     @setting = CustomMessageSetting.find_or_default
   end

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -9,7 +9,8 @@ module CustomMessageSettingsHelper
   end
 
   def normal_mode_input_fields(setting, lang)
-    return '' if setting.value[:custom_messages].is_a?(String) || setting.value[:custom_messages].blank?
+    return '' if setting.custom_messages.is_a?(String) || setting.custom_messages.blank?
+
     content = ActiveSupport::SafeBuffer.new
     custom_messages_hash = setting.custom_messages_to_flatten_hash(lang.to_s)
     custom_messages_hash.each do |k, v|

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -2,6 +2,7 @@ module CustomMessageSettingsHelper
   def available_message_options(setting, lang)
     options = [['', '']] +
                 CustomMessageSetting.flatten_hash(MessageCustomize::Locale.available_messages(lang))
+                .select{|_k, v| v.is_a?(String)}
                 .map{|k, v| ["#{k}: #{v}", k]}
 
     options_for_select(options, disabled: setting.custom_messages_to_flatten_hash(lang).keys)

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -23,8 +23,8 @@ class CustomMessageSetting < Setting
   end
 
   def custom_messages_to_yaml
-    if custom_messages.is_a?(Hash)
-      messages = custom_messages
+    messages = custom_messages
+    if messages.is_a?(Hash)
       messages.present? ? YAML.dump(messages) : ''
     else
       raw_custom_messages

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -85,7 +85,8 @@ class CustomMessageSetting < Setting
 
   # { date: { formats: { defaults: '%m/%d/%Y'}}} to {'date.formats.defaults' => '%m/%d/%Y'}
   def self.flatten_hash(hash=nil)
-    hash = self.to_hash unless hash
+    hash ||= self.to_hash
+
     hash.each_with_object({}) do |(key, value), content|
       next self.flatten_hash(value).each do |k, v|
         content["#{key}.#{k}".intern] = v
@@ -111,7 +112,7 @@ class CustomMessageSetting < Setting
   private
 
   def custom_message_keys_are_available
-    return false if !value[:custom_messages].is_a?(Hash) || errors.present?
+    return if errors.present?
 
     en_translation_hash = self.class.flatten_hash(MessageCustomize::Locale.available_messages('en'))
     custom_message_keys = custom_messages.values.inject([]){|ar, val| ar + self.class.flatten_hash(val).keys}.uniq
@@ -128,7 +129,7 @@ class CustomMessageSetting < Setting
   end
 
   def custom_message_languages_are_available
-    return false if !value[:custom_messages].is_a?(Hash) || errors.present?
+    return if errors.present?
 
     unavailable_languages =
       custom_messages.keys.compact.reject do |language|
@@ -136,11 +137,12 @@ class CustomMessageSetting < Setting
       end
     if unavailable_languages.present?
       self.errors.add(:base, l(:error_unavailable_languages) + " [#{unavailable_languages.join(', ')}]")
-      false
     end
   end
 
   def convertible_to_yaml
+    return if errors.present?
+
     YAML.dump(self.value[:custom_messages])
   end
 
@@ -150,7 +152,6 @@ class CustomMessageSetting < Setting
         self.errors.add(key, value)
       end
       @errs = nil
-      false
     end
   end
 end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -141,8 +141,14 @@ class CustomMessageSetting < Setting
   end
 
   def convertible_to_yaml
-    errors.add(:base, l(:error_invalid_yaml_format)) if raw_custom_messages.present? && !raw_custom_messages.is_a?(Hash)
-
-    YAML.dump(raw_custom_messages)
+    raw_messages = raw_custom_messages
+    if raw_messages.present? && !raw_messages.is_a?(Hash)
+      begin
+        messages = YAML.load("#{raw_messages}")
+        errors.add(:base, l(:error_invalid_yaml_format))
+      rescue Psych::SyntaxError => e
+        errors.add(:base, e.message)
+      end
+    end
   end
 end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -53,6 +53,7 @@ class CustomMessageSetting < Setting
   rescue Psych::SyntaxError => e
     self.value = self.value.merge({custom_messages: yaml})
     errors.add(:base, e.message)
+    false
   end
 
   def toggle_enabled!

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -114,7 +114,7 @@ class CustomMessageSetting < Setting
     return false if !value[:custom_messages].is_a?(Hash) || errors.present?
 
     en_translation_hash = self.class.flatten_hash(MessageCustomize::Locale.available_messages('en'))
-    custom_message_keys = custom_messages.values.sum{|val| self.class.flatten_hash(val).keys}.uniq
+    custom_message_keys = custom_messages.values.sum([]){|val| self.class.flatten_hash(val).keys}.uniq
 
     unused_keys = custom_message_keys.reject{|k| en_translation_hash.keys.include?(:"#{k}")}
     unusable_type_of_keys = (custom_message_keys - unused_keys).reject{|k| en_translation_hash[:"#{k}"].is_a?(String)}

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -50,6 +50,9 @@ class CustomMessageSetting < Setting
     messages = YAML.load(yaml)
     self.value = self.value.deep_merge({custom_messages: messages.presence || {}})
     self.save
+  rescue Psych::SyntaxError => e
+    self.value = self.value.merge({custom_messages: yaml})
+    errors.add(:base, e.message)
   end
 
   def toggle_enabled!
@@ -134,9 +137,8 @@ class CustomMessageSetting < Setting
   end
 
   def convertible_to_yaml
-    return if errors.present?
+    errors.add(:base, l(:error_invalid_yaml_format)) if raw_custom_messages.present? && !raw_custom_messages.is_a?(Hash)
 
-    messages = raw_custom_messages
-    errors.add(:base, l(:error_invalid_yaml_format)) if messages.present? && !messages.is_a?(Hash)
+    YAML.dump(raw_custom_messages)
   end
 end

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -23,7 +23,7 @@ class CustomMessageSetting < Setting
   end
 
   def custom_messages_to_yaml
-    if self.valid?
+    if custom_messages.is_a?(Hash)
       messages = custom_messages
       messages.present? ? YAML.dump(messages) : ''
     else

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -143,7 +143,7 @@ class CustomMessageSetting < Setting
     raw_messages = raw_custom_messages
     if raw_messages.present? && !raw_messages.is_a?(Hash)
       begin
-        messages = YAML.load("#{raw_messages}")
+        YAML.load("#{raw_messages}")
         errors.add(:base, l(:error_invalid_yaml_format))
       rescue Psych::SyntaxError => e
         errors.add(:base, e.message)

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -72,7 +72,6 @@ class CustomMessageSetting < Setting
   # { date: { formats: { defaults: '%m/%d/%Y'}}} to {'date.formats.defaults' => '%m/%d/%Y'}
   def self.flatten_hash(hash=nil)
     return hash unless hash.is_a?(Hash)
-    hash ||= hash.to_hash
 
     hash.each_with_object({}) do |(key, value), content|
       next self.flatten_hash(value).each do |k, v|

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -42,13 +42,13 @@ class CustomMessageSetting < Setting
         original_custom_messages
       end
 
-    self.value = self.value.deep_merge({custom_messages: messages.presence || {}})
+    self.value = self.value.merge({custom_messages: messages.presence || {}})
     self.save
   end
 
   def update_with_custom_messages_yaml(yaml)
     messages = YAML.load(yaml)
-    self.value = self.value.deep_merge({custom_messages: messages.presence || {}})
+    self.value = self.value.merge({custom_messages: messages.presence || {}})
     self.save
   rescue Psych::SyntaxError => e
     self.value = self.value.merge({custom_messages: yaml})

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -75,7 +75,8 @@ class CustomMessageSetting < Setting
 
   # { date: { formats: { defaults: '%m/%d/%Y'}}} to {'date.formats.defaults' => '%m/%d/%Y'}
   def self.flatten_hash(hash=nil)
-    hash ||= self.to_hash
+    return hash unless hash.is_a?(Hash)
+    hash ||= hash.to_hash
 
     hash.each_with_object({}) do |(key, value), content|
       next self.flatten_hash(value).each do |k, v|

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -114,7 +114,7 @@ class CustomMessageSetting < Setting
     return false if !value[:custom_messages].is_a?(Hash) || errors.present?
 
     en_translation_hash = self.class.flatten_hash(MessageCustomize::Locale.available_messages('en'))
-    custom_message_keys = custom_messages.values.sum([]){|val| self.class.flatten_hash(val).keys}.uniq
+    custom_message_keys = custom_messages.values.inject([]){|ar, val| ar + self.class.flatten_hash(val).keys}.uniq
 
     unused_keys = custom_message_keys.reject{|k| en_translation_hash.keys.include?(:"#{k}")}
     unusable_type_of_keys = (custom_message_keys - unused_keys).reject{|k| en_translation_hash[:"#{k}"].is_a?(String)}

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -98,7 +98,6 @@ class CustomMessageSetting < Setting
     new_hash = {}
     hash.each do |key, value|
       h = value
-      h = YAML.load(value) if value.first == '[' && value.last == ']'
       key.to_s.split('.').reverse_each do |k|
         h = {k => h}
       end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
   text_for_your_reference: "If you do not know how to write, please refer to %{value}."
   error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
-  error_unusable_type_of_keys: This plugin can not customize values other than string..
+  error_unusable_type_of_keys: This plugin can not customize values other than string.
   error_invalid_yaml_format: The format of yaml is invalid.
   error_value_too_long: "Could not save because there are too many custom messages. Please reduce the amount of messages custom messages."
   notice_enabled_customize: Successful in enable messages customization.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -10,7 +10,7 @@ en:
   text_for_your_reference: "If you do not know how to write, please refer to %{value}."
   error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
-  error_unusable_type_of_keys: This plugin can not customize values other than string. If you want to customize, please rewrite the file in config/locales directly.
+  error_unusable_type_of_keys: This plugin can not customize values other than string..
   error_invalid_yaml_format: The format of yaml is invalid.
   error_value_too_long: "Could not save because there are too many custom messages. Please reduce the amount of messages custom messages."
   notice_enabled_customize: Successful in enable messages customization.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,9 @@ en:
   text_placeholder_choose_key: Please select the message you want to change.
   text_description_of_search_box: You can enter search terms in the search box to narrow down the results.
   text_for_your_reference: "If you do not know how to write, please refer to %{value}."
-  error_unavailable_keys: The keys not present in Redmine are used.
+  error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.
+  error_unusable_type_of_keys: This plugin can not customize values other than string. If you want to customize, please rewrite the file in config/locales directly.
   error_invalid_yaml_format: The format of yaml is invalid.
   error_value_too_long: "Could not save because there are too many custom messages. Please reduce the amount of messages custom messages."
   notice_enabled_customize: Successful in enable messages customization.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,8 +8,9 @@ ja:
   text_placeholder_choose_key: 変更したい文言を選択してください。
   text_description_of_search_box: 検索ボックスにキーワードを入力することで、選択肢を絞り込むことが出来ます。
   text_for_your_reference: "もし書き方がわからない場合は、%{value}が参考になるはずです。"
-  error_unavailable_keys: Redmineに存在しないキーが利用されています。
+  error_unused_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。
+  error_unusable_type_of_keys: このプラグインでは文字列以外の値をカスタマイズすることは出来ません。カスタマイズしたい場合はconfig/locales以下のファイルを直接書き換えてください。
   error_invalid_yaml_format: YAMLの形式が正しくありません。
   error_value_too_long: "カスタマイズするメッセージが多すぎるため保存できませんでした。カスタマイズするメッセージを減らしてください。"
   notice_enabled_customize: メッセージのカスタマイズを有効に変更しました。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -10,7 +10,7 @@ ja:
   text_for_your_reference: "もし書き方がわからない場合は、%{value}が参考になるはずです。"
   error_unused_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。
-  error_unusable_type_of_keys: このプラグインでは文字列以外の値をカスタマイズすることは出来ません。カスタマイズしたい場合はconfig/locales以下のファイルを直接書き換えてください。
+  error_unusable_type_of_keys: このプラグインでは文字列以外の値をカスタマイズすることは出来ません。
   error_invalid_yaml_format: YAMLの形式が正しくありません。
   error_value_too_long: "カスタマイズするメッセージが多すぎるため保存できませんでした。カスタマイズするメッセージを減らしてください。"
   notice_enabled_customize: メッセージのカスタマイズを有効に変更しました。

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,3 +1,11 @@
 # Load the normal Rails helper
 require File.expand_path(File.dirname(__FILE__) + '/../../../test/test_helper')
+
+# Add missing settings when ENV['RAILS_ENV'] is development
+if Rails.env.development?
+  Rails.application.config.redmine_verify_sessions = false
+  Rails.application.config.action_controller.allow_forgery_protection = false
+  ActionController::Base.allow_forgery_protection = false
+end
+
 ActiveRecord::FixtureSet.create_fixtures(File.dirname(__FILE__) + '/fixtures', 'custom_message_settings')

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -66,7 +66,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     @custom_message_setting.value = { custom_messages: {} }
     assert_equal '', @custom_message_setting.custom_messages_to_yaml
 
-    @custom_message_setting.instance_variable_set('@invalid_yaml', 'test')
+    @custom_message_setting.value = { custom_messages: 'test' }
     assert_equal 'test', @custom_message_setting.custom_messages_to_yaml
   end
 
@@ -89,7 +89,6 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   def test_update_with_custom_messages_yaml_if_yaml_is_invalid
     yaml = "---\nen:\n  label_home: Home3\ninvalid-string"
     assert_not @custom_message_setting.update_with_custom_messages_yaml(yaml)
-    assert_equal "---\nen:\n  label_home: Home3\ninvalid-string", @custom_message_setting.instance_variable_get('@invalid_yaml')
     assert_equal "(<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1", @custom_message_setting.errors[:base].first
   end
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -28,6 +28,12 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal "#{l(:error_unavailable_languages)} [foo]", @custom_message_setting.errors[:base].first
   end
 
+  def test_validate_with_invalid_yaml_should_invalid
+    @custom_message_setting.value = { custom_messages: "---\nen:\n  label_home: Home3\ninvalid-string" }
+    assert_not @custom_message_setting.valid?
+    assert_equal "(<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1", @custom_message_setting.errors[:base].first
+  end
+
   def test_find_or_default
     assert_equal @custom_message_setting, CustomMessageSetting.find_or_default
   end
@@ -85,11 +91,6 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     yaml = "---\nen:\n  label_home: Home3"
     assert @custom_message_setting.update_with_custom_messages_yaml(yaml)
     assert_equal ({ 'label_home' => 'Home3' }), @custom_message_setting.custom_messages('en')
-  end
-  def test_update_with_custom_messages_yaml_if_yaml_is_invalid
-    yaml = "---\nen:\n  label_home: Home3\ninvalid-string"
-    assert_not @custom_message_setting.update_with_custom_messages_yaml(yaml)
-    assert_equal "(<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1", @custom_message_setting.errors[:base].first
   end
 
   def test_toggle_enabled!

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -66,7 +66,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     @custom_message_setting.value = { custom_messages: {} }
     assert_equal '', @custom_message_setting.custom_messages_to_yaml
 
-    @custom_message_setting.value = { custom_messages: 'test' }
+    @custom_message_setting.instance_variable_set('@invalid_yaml', 'test')
     assert_equal 'test', @custom_message_setting.custom_messages_to_yaml
   end
 
@@ -89,6 +89,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   def test_update_with_custom_messages_yaml_if_yaml_is_invalid
     yaml = "---\nen:\n  label_home: Home3\ninvalid-string"
     assert_not @custom_message_setting.update_with_custom_messages_yaml(yaml)
+    assert_equal "---\nen:\n  label_home: Home3\ninvalid-string", @custom_message_setting.instance_variable_get('@invalid_yaml')
     assert_equal "(<unknown>): could not find expected ':' while scanning a simple key at line 4 column 1", @custom_message_setting.errors[:base].first
   end
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -10,15 +10,21 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
-  def test_validate_with_not_available_keys_should_return_false
-    @custom_message_setting.value = { custom_messages: { 'en' => {'foobar' => 'foobar' }} }
-    assert_not @custom_message_setting.save
-    assert_equal "#{l(:error_unavailable_keys)} keys: [foobar]", @custom_message_setting.errors[:base].first
+  def test_validate_with_unused_keys_should_invalid
+    @custom_message_setting.value = { custom_messages: { 'en' => {'foo' => 'bar' }} }
+    assert_not @custom_message_setting.valid?
+    assert_equal "#{l(:error_unused_keys)} keys: [foo]", @custom_message_setting.errors[:base].first
   end
 
-  def test_validate_with_not_available_languages_should_return_false
+  def test_validate_with_unusable_type_of_keys_should_invalid
+    @custom_message_setting.value = { custom_messages: { 'en' => {'date' => {'order' => 'foobar' }}} }
+    assert_not @custom_message_setting.valid?
+    assert_equal "#{l(:error_unusable_type_of_keys)} keys: [date.order]", @custom_message_setting.errors[:base].first
+  end
+
+  def test_validate_with_not_available_languages_should_invalid
     @custom_message_setting.value = { custom_messages: { 'foo' => {'label_home' => 'Home' }} }
-    assert_not @custom_message_setting.save
+    assert_not @custom_message_setting.valid?
     assert_equal "#{l(:error_unavailable_languages)} [foo]", @custom_message_setting.errors[:base].first
   end
 


### PR DESCRIPTION
Fix: #11

Make it impossible to customize a key whose value is something other than a string.
example: date.day_names, number.precision

* Add check of value class in custom_message_keys_are_available
* Remove keys with values other than strings from available_message_options