### PR TITLE
Remove a leading zero from the minor version

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -2,7 +2,7 @@ require_dependency 'message_customize/locale'
 
 p = Redmine::Plugin.register :redmine_message_customize do
   name 'Redmine customize messages plugin'
-  version '0.01.0'
+  version '0.1.0'
   description 'This is a plugin that allows messages in Redmine to be overwritten from the admin view'
   settings default: { custom_messages: {} }
   menu :admin_menu, :custom_messages, { controller: 'custom_message_settings', action: 'edit' },


### PR DESCRIPTION
Version numbers must not contain leading zeros in Semantic Versioning.
https://semver.org/#spec-item-2

Due to the unnecessary zero, the "Check for updates" feature misrecognizes that the installed plugin is not the latest version.

![image](https://user-images.githubusercontent.com/114863/64100296-4ce74180-cda6-11e9-8fb8-78383a42f104.png)
