### PR TITLE
Only allow plugin text to be overwritten when there is 35_change_load_order_locales

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ $ cp plugins/redmine_message_customize/35_change_load_order_locales.rb config/in
 $ # redmine restart
 ```
 
-:warning: In order to customize messages of other plugins, it is necessary to copy redmine_message_customize/35_change_load_order_locales.rb into redmine/config/initializers.
+:warning: In order to customize messages of other plugins, it is necessary to copy redmine_message_customize/35_change_load_order_locales.rb into redmine/config/initializers.  
+If you don't have redmine/config/initializers/35_change_load_order_locales.rb, you can customize only messages other than plugins.
 
 ## Usage
 

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -12,8 +12,14 @@
 <% if @setting.errors.any? %>
   <%= error_messages_for(@setting) %>
 <% end %>
-<p class='toggle-enable'>
+<div class='message-customize-menu'>
   <%= link_to (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize)), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon icon-settings' %> /
   <%= open_default_messages_window_link(@lang) %>
-</p>
+
+  <% unless MessageCustomize::Locale.customizable_plugin_messages? %>
+    <p>
+      <%= l(:text_unable_to_customize_plugin_messages, MessageCustomize::Locale::CHANGE_LOARD_ORDER_LOCALES_FILE_PATH) %>
+    </p>
+  <% end %>
+</div>
 <%= render_tabs (@setting.errors.any? ? [] : [{name: 'normal', partial: 'normal_tab', label: 'label_normal_tab'}]) + [{name: 'yaml', partial: 'yaml_tab', label: 'label_yaml_tab'}] %>

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -18,7 +18,7 @@
 
   <% unless MessageCustomize::Locale.customizable_plugin_messages? %>
     <p>
-      <%= l(:text_unable_to_customize_plugin_messages, MessageCustomize::Locale::CHANGE_LOARD_ORDER_LOCALES_FILE_PATH) %>
+      <%= l(:text_unable_to_customize_plugin_messages) %>
     </p>
   <% end %>
 </div>

--- a/assets/stylesheets/custom_messages.css
+++ b/assets/stylesheets/custom_messages.css
@@ -36,6 +36,10 @@
   color: white;
 }
 
-p.toggle-enable {
+div.message-customize-menu {
   text-align: right;
+}
+div.message-customize-menu p {
+  color: gray;
+  font-size: 5px;
 }

--- a/assets/stylesheets/custom_messages.css
+++ b/assets/stylesheets/custom_messages.css
@@ -42,4 +42,5 @@ div.message-customize-menu {
 div.message-customize-menu p {
   color: gray;
   font-size: 10px;
+  margin: 5px;
 }

--- a/assets/stylesheets/custom_messages.css
+++ b/assets/stylesheets/custom_messages.css
@@ -41,5 +41,5 @@ div.message-customize-menu {
 }
 div.message-customize-menu p {
   color: gray;
-  font-size: 5px;
+  font-size: 10px;
 }

--- a/assets/stylesheets/custom_messages.css
+++ b/assets/stylesheets/custom_messages.css
@@ -42,5 +42,5 @@ div.message-customize-menu {
 div.message-customize-menu p {
   color: gray;
   font-size: 10px;
-  margin: 5px;
+  margin: 5px 0px;
 }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
   text_description_of_search_box: You can enter search terms in the search box to narrow down the results.
   text_for_your_reference: If you do not know how to write, please refer to "%{value}".
   text_disabled_customize: Message customization by this plugin is disabled.
-  text_unable_to_customize_plugin_messages: You cannot customize the plugin messages because there is no "%{value}".
+  text_unable_to_customize_plugin_messages: Impossible to customize the plugin messages.
 
   error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -8,8 +8,8 @@ en:
   text_placeholder_choose_key: Please select the message you want to change.
   text_description_of_search_box: You can enter search terms in the search box to narrow down the results.
   text_for_your_reference: If you do not know how to write, please refer to "%{value}".
-  text_disabled_customize: Message customization by this plugin is disabled.
-  text_unable_to_customize_plugin_messages: Impossible to customize the plugin messages.
+  text_disabled_customize: All message customizations are disabled.
+  text_unable_to_customize_plugin_messages: Impossible to customize the messages of the plugins.
 
   error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,6 +9,7 @@ en:
   text_description_of_search_box: You can enter search terms in the search box to narrow down the results.
   text_for_your_reference: If you do not know how to write, please refer to "%{value}".
   text_disabled_customize: Message customization by this plugin is disabled.
+  text_unable_to_customize_plugin_messages: You cannot customize the plugin messages because there is no "%{value}".
 
   error_unused_keys: The keys not present in Redmine are used.
   error_unavailable_languages: The languages not present in Redmine are used.

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,8 +8,8 @@ ja:
   text_placeholder_choose_key: 変更したい文言を選択してください。
   text_description_of_search_box: 検索ボックスにキーワードを入力することで、選択肢を絞り込むことが出来ます。
   text_for_your_reference: "もし書き方がわからない場合は、「%{value}」が参考になるはずです。"
-  text_disabled_customize: このプラグインによるメッセージのカスタマイズは無効になっています。
-  text_unable_to_customize_plugin_messages: "プラグインのメッセージはカスタマイズできません。"
+  text_disabled_customize: メッセージのカスタマイズはすべて無効になっています。
+  text_unable_to_customize_plugin_messages: Redmineに入っているプラグインのメッセージはカスタマイズできません。
 
   error_unused_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,7 +9,7 @@ ja:
   text_description_of_search_box: 検索ボックスにキーワードを入力することで、選択肢を絞り込むことが出来ます。
   text_for_your_reference: "もし書き方がわからない場合は、「%{value}」が参考になるはずです。"
   text_disabled_customize: このプラグインによるメッセージのカスタマイズは無効になっています。
-  text_unable_to_customize_plugin_messages: "「%{value}」が無いためプラグインのメッセージはカスタマイズできません。"
+  text_unable_to_customize_plugin_messages: "プラグインのメッセージはカスタマイズできません。"
 
   error_unused_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,7 @@ ja:
   text_description_of_search_box: 検索ボックスにキーワードを入力することで、選択肢を絞り込むことが出来ます。
   text_for_your_reference: "もし書き方がわからない場合は、「%{value}」が参考になるはずです。"
   text_disabled_customize: このプラグインによるメッセージのカスタマイズは無効になっています。
+  text_unable_to_customize_plugin_messages: "「%{value}」が無いためプラグインのメッセージはカスタマイズできません。"
 
   error_unused_keys: Redmineに存在しないキーが利用されています。
   error_unavailable_languages: Redmineで利用できない言語が利用されています。

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -18,7 +18,7 @@ module MessageCustomize
           available_languages.each do |lang|
             redmine_root_locale_path = Rails.root.join('config', 'locales', "#{lang}.yml")
             if File.exist?(redmine_root_locale_path)
-              @available_messages[:"#{lang}"] = (I18n.backend.send(:load_yaml, redmine_root_locale_path)[lang] || {}).deep_symbolize_keys
+              @available_messages[:"#{lang}"] = (I18n.backend.send(:load_yml, redmine_root_locale_path)[lang] || {}).deep_symbolize_keys
             end
           end
         end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -1,6 +1,7 @@
 module MessageCustomize
   module Locale
     @available_messages = {}
+    CHANGE_LOARD_ORDER_LOCALES_FILE_PATH = 'config/initializers/35_change_load_order_locales.rb'
 
     class << self
       def available_locales
@@ -11,7 +12,16 @@ module MessageCustomize
         available_languages = self.find_language(languages.flatten)
         paths = I18n.load_path.select {|path| available_languages.include?(File.basename(path, '.*').to_s)}
         I18n.backend.load_translations(paths)
-        available_languages.each{|lang| @available_messages[:"#{lang}"] = I18n.backend.send(:translations)[:"#{lang}"] || {}}
+        if customizable_plugin_messages?
+          available_languages.each{|lang| @available_messages[:"#{lang}"] = I18n.backend.send(:translations)[:"#{lang}"] || {}}
+        else
+          available_languages.each do |lang|
+            redmine_root_locale_path = Rails.root.join('config', 'locales', "#{lang}.yml")
+            if File.exist?(redmine_root_locale_path)
+              @available_messages[:"#{lang}"] = (I18n.backend.send(:load_yaml, redmine_root_locale_path)[lang] || {}).deep_symbolize_keys
+            end
+          end
+        end
       end
 
       def find_language(language=nil)
@@ -28,6 +38,10 @@ module MessageCustomize
         lang = :"#{lang}"
         self.reload!(lang) if @available_messages[lang].blank?
         @available_messages[lang] || {}
+      end
+
+      def customizable_plugin_messages?
+        @customizable_plugin_messages ||= File.exist?(Rails.root.join(CHANGE_LOARD_ORDER_LOCALES_FILE_PATH))
       end
     end
   end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -1,7 +1,7 @@
 module MessageCustomize
   module Locale
     @available_messages = {}
-    CHANGE_LOARD_ORDER_LOCALES_FILE_PATH = 'config/initializers/35_change_load_order_locales.rb'
+    CHANGE_LOAD_ORDER_LOCALES_FILE_PATH = 'config/initializers/35_change_load_order_locales.rb'
 
     class << self
       def available_locales
@@ -41,7 +41,7 @@ module MessageCustomize
       end
 
       def customizable_plugin_messages?
-        @customizable_plugin_messages ||= File.exist?(Rails.root.join(CHANGE_LOARD_ORDER_LOCALES_FILE_PATH))
+        @customizable_plugin_messages ||= File.exist?(Rails.root.join(CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
       end
     end
   end

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -67,7 +67,7 @@ class LocaleTest < ActiveSupport::TestCase
   end
 
   def test_customizable_plugin_messages?
-    expect = File.exist?(Rails.root.join('config', 'initializers', MessageCustomize::Locale::CHANGE_LOARD_ORDER_LOCALES_FILE_PATH))
+    expect = File.exist?(Rails.root.join('config', 'initializers', MessageCustomize::Locale::CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
     assert_equal expect, MessageCustomize::Locale.customizable_plugin_messages?
   end
 end

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -67,7 +67,7 @@ class LocaleTest < ActiveSupport::TestCase
   end
 
   def test_customizable_plugin_messages?
-    expect = File.exist?(Rails.root.join('config', 'initializers', MessageCustomize::Locale::CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
+    expect = File.exist?(Rails.root.join(MessageCustomize::Locale::CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
     assert_equal expect, MessageCustomize::Locale.customizable_plugin_messages?
   end
 end


### PR DESCRIPTION
You can customize the plugin messages only if you have "config/initializers/35_change_load_order_locales.rb".

In this pull request, if there is no "config/initializers/35_change_load_order_locales.rb", the customization messages will not include the plug-in message.

* Change the value in @available_messages according to MessageCustomize::Locale.customizable_plugin_messages?
* Display a message if MessageCustomize::Locale.customizable_plugin_messages? is false
![image](https://user-images.githubusercontent.com/14245262/64511839-166a7300-d320-11e9-99e5-53cd2faa0553.png)
