### PR TITLE
Fix the wrong version number

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Redmine message customize plugin changelog
 
-## v0.01.0
+## v0.1.0
 
 * [Fix "Infinite loop occurs in the process of calling I18n.available_locales"(Redmine 4.1 compatible)](https://github.com/ishikawa999/redmine_message_customize/issues/12)
 * [Add a feature to show default messages](https://github.com/ishikawa999/redmine_message_customize/issues/6)


### PR DESCRIPTION
In GH-29, the version number in init.rb has been fixed from "0.01.0" to "0.1.0". But the version number in the changelog is still "0.01.0". It should have been fixed along with init.rb.