### PR TITLE
Add MessageCustomize::Hooks after_plugins_loaded #44

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,12 +8,13 @@ This plugin changes the translation of the wording on the screen defined in "con
 ```
 $ cd /your/path/redmine
 $ git clone https://github.com/ishikawa999/redmine_message_customize.git plugins/redmine_message_customize
+$ # When Redmine 4.1 or lower versions
 $ cp plugins/redmine_message_customize/35_change_load_order_locales.rb config/initializers/35_change_load_order_locales.rb
 $ # redmine restart
 ```
 
-:warning: In order to customize messages of other plugins, it is necessary to copy redmine_message_customize/35_change_load_order_locales.rb into redmine/config/initializers.  
-If you don't have redmine/config/initializers/35_change_load_order_locales.rb, you can customize only messages other than plugins.
+:warning To customize messages for other plugins in **Redmine 4.1 or lower versions**, redmine_message_customize/35_change_load_order_locales.rb It is necessary to copy the file to redmine/config/initializers. 
+If redmine/config/initializers/35_change_load_order_locales.rb is missing, only non-plugin messages can be customized.
 
 ## Usage
 

--- a/init.rb
+++ b/init.rb
@@ -1,4 +1,7 @@
+# frozen_string_literal: true
+
 require File.expand_path('../lib/message_customize/locale', __FILE__)
+require File.expand_path('../lib/message_customize/hooks', __FILE__)
 
 p = Redmine::Plugin.register :redmine_message_customize do
   name 'Redmine message customize plugin'

--- a/lib/message_customize/hooks.rb
+++ b/lib/message_customize/hooks.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module MessageCustomize
+  class Hooks < Redmine::Hook::ViewListener
+    # The language file for redmine_message_customize should be given the highest priority because it overrides other plugin languages.
+    # Set the language file to be loaded with the highest priority after all plugins have finished loading.
+    def after_plugins_loaded()
+      p = Redmine::Plugin.find(:redmine_message_customize)
+      custom_locales = Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))
+      Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path - custom_locales + custom_locales)
+    end
+  end
+end

--- a/lib/message_customize/hooks.rb
+++ b/lib/message_customize/hooks.rb
@@ -4,7 +4,7 @@ module MessageCustomize
   class Hooks < Redmine::Hook::ViewListener
     # The language file for redmine_message_customize should be given the highest priority because it overrides other plugin languages.
     # Set the language file to be loaded with the highest priority after all plugins have finished loading.
-    def after_plugins_loaded()
+    def after_plugins_loaded(_context)
       p = Redmine::Plugin.find(:redmine_message_customize)
       custom_locales = Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))
       Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path - custom_locales + custom_locales)

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -7,12 +7,12 @@ module MessageCustomize
 
     class << self
       def available_locales
-        @available_locales ||= I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
+        @available_locales ||= Rails.application.config.i18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
       end
 
       def reload!(*languages)
         available_languages = self.find_language(languages.flatten)
-        paths = I18n.load_path.select {|path| available_languages.include?(File.basename(path, '.*').to_s)}
+        paths = Rails.application.config.i18n.load_path.select {|path| available_languages.include?(File.basename(path, '.*').to_s)}
         I18n.backend.load_translations(paths)
         if customizable_plugin_messages?
           available_languages.each{|lang| @available_messages[:"#{lang}"] = I18n.backend.send(:translations)[:"#{lang}"] || {}}

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -17,16 +17,12 @@ module MessageCustomize
         if customizable_plugin_messages?
           available_languages.each{|lang| @available_messages[:"#{lang}"] = I18n.backend.send(:translations)[:"#{lang}"] || {}}
         else
-          p 'customizable_plugin_messages false'
-          p available_languages
           available_languages.each do |lang|
             redmine_root_locale_path = Rails.root.join('config', 'locales', "#{lang}.yml")
-            p File.exist?(redmine_root_locale_path)
             if File.exist?(redmine_root_locale_path)
               loaded_yml = I18n.backend.send(:load_yml, redmine_root_locale_path)
-              p loaded_yml
               loaded_yml = loaded_yml.first if loaded_yml.is_a?(Array)
-              @available_messages[:"#{lang}"] = (loaded_yml[lang] || {}).deep_symbolize_keys
+              @available_messages[:"#{lang}"] = (loaded_yml[lang] || loaded_yml[lang.to_sym] || {}).deep_symbolize_keys
             end
           end
         end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -17,10 +17,14 @@ module MessageCustomize
         if customizable_plugin_messages?
           available_languages.each{|lang| @available_messages[:"#{lang}"] = I18n.backend.send(:translations)[:"#{lang}"] || {}}
         else
+          p 'customizable_plugin_messages false'
+          p available_languages
           available_languages.each do |lang|
             redmine_root_locale_path = Rails.root.join('config', 'locales', "#{lang}.yml")
+            p File.exist?(redmine_root_locale_path)
             if File.exist?(redmine_root_locale_path)
               loaded_yml = I18n.backend.send(:load_yml, redmine_root_locale_path)
+              p loaded_yml
               loaded_yml = loaded_yml.first if loaded_yml.is_a?(Array)
               @available_messages[:"#{lang}"] = (loaded_yml[lang] || {}).deep_symbolize_keys
             end

--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 module MessageCustomize
   module Locale
     @available_messages = {}
@@ -5,7 +7,7 @@ module MessageCustomize
 
     class << self
       def available_locales
-        @locales ||= I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
+        @available_locales ||= I18n.load_path.map {|path| File.basename(path, '.*')}.uniq.sort.map(&:to_sym)
       end
 
       def reload!(*languages)
@@ -43,7 +45,7 @@ module MessageCustomize
       end
 
       def customizable_plugin_messages?
-        @customizable_plugin_messages ||= File.exist?(Rails.root.join(CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
+        Rails.application.config.i18n.load_path.last.include?('redmine_message_customize')
       end
     end
   end

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -8,7 +8,7 @@ class CustomMessageSettingsControllerTest < defined?(Redmine::ControllerTest) ? 
   def setup
     @request.session[:user_id] = 1 # admin
     MessageCustomize::Locale.reload!('en')
-    I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
+    Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
   # custom_message_settings/edit

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -7,7 +7,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   def setup
     @custom_message_setting = CustomMessageSetting.find(1)
     MessageCustomize::Locale.reload!('en')
-    I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
+    Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 
   def test_validate_with_unused_keys_should_invalid

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -55,7 +55,6 @@ class LocaleTest < ActiveSupport::TestCase
     MessageCustomize::Locale.instance_variable_set(:@available_messages, {})
 
     en_available_messages = MessageCustomize::Locale.available_messages('en')
-    p en_available_messages
     assert_equal 'am', en_available_messages[:time][:am]
     assert_nil en_available_messages[:label_custom_messages] # plugin messages
     assert_equal [:en], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -6,7 +6,7 @@ class LocaleTest < ActiveSupport::TestCase
 
     def setup
       MessageCustomize::Locale.reload!('en')
-      I18n.load_path = (I18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
+      Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
     end
 
   def test_reload!
@@ -67,7 +67,13 @@ class LocaleTest < ActiveSupport::TestCase
   end
 
   def test_customizable_plugin_messages?
-    expect = File.exist?(Rails.root.join(MessageCustomize::Locale::CHANGE_LOAD_ORDER_LOCALES_FILE_PATH))
-    assert_equal expect, MessageCustomize::Locale.customizable_plugin_messages?
+    original_load_path = Rails.application.config.i18n.load_path
+    Rails.application.config.i18n.load_path = (original_load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', 'ja.rb'))).uniq
+    assert_equal true, MessageCustomize::Locale.customizable_plugin_messages?
+
+    Rails.application.config.i18n.load_path += [Rails.root.join('plugins', 'dummy', 'config', 'locales', 'en.yml').to_s]
+    assert_equal false, MessageCustomize::Locale.customizable_plugin_messages?
+    # cleaning
+    Rails.application.config.i18n.load_path = original_load_path
   end
 end

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -55,6 +55,7 @@ class LocaleTest < ActiveSupport::TestCase
     MessageCustomize::Locale.instance_variable_set(:@available_messages, {})
 
     en_available_messages = MessageCustomize::Locale.available_messages('en')
+    p en_available_messages
     assert_equal 'am', en_available_messages[:time][:am]
     assert_nil en_available_messages[:label_custom_messages] # plugin messages
     assert_equal [:en], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys


### PR DESCRIPTION
In Redmine 4.2 and later, override language with after_plugins_loaded
hook instead of 35_change_load_order_locales.rb