### PR TITLE
Add a process to look at the timestamp and reload the term if it is not latest

### DIFF
--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -53,7 +53,7 @@ class CustomMessageSettingsController < ApplicationController
   def set_lang
     @lang =
       MessageCustomize::Locale.find_language(
-        params[:lang].presence || @setting.custom_messages.keys.first || User.current.language.presence || Setting.default_language
+        params[:lang].presence || @setting.custom_messages.keys.first || current_user_language
       )
   end
 end

--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -12,8 +12,6 @@ class CustomMessageSettingsController < ApplicationController
   end
 
   def update
-    languages = @setting.using_languages
-
     if setting_params.key?(:custom_messages) || params[:tab] == 'normal'
       @setting.update_with_custom_messages(setting_params[:custom_messages].try(:to_unsafe_h).try(:to_hash) || {}, @lang)
     elsif setting_params.key?(:custom_messages_yaml)
@@ -22,9 +20,6 @@ class CustomMessageSettingsController < ApplicationController
 
     if @setting.errors.blank?
       flash[:notice] = l(:notice_successful_update)
-      languages += @setting.using_languages
-      MessageCustomize::Locale.reload!(languages)
-
       redirect_to edit_custom_message_settings_path(tab: params[:tab], lang: @lang)
     else
       render :edit

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -18,8 +18,8 @@ class CustomMessageSetting < Setting
     messages || {}
   end
 
-  def custom_messages_with_timestamp(lang=nil, check_enabled=false)
-    messages = self.custom_messages(lang, check_enabled)
+  def custom_messages_with_timestamp(lang)
+    messages = self.custom_messages(lang, true)
     messages.merge({'redmine_message_customize_timestamp' => self.try(:updated_on).to_i.to_s})
   end
 

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -68,15 +68,6 @@ class CustomMessageSetting < Setting
     self.save
   end
 
-  def using_languages
-    messages = self.custom_messages
-    if messages.is_a?(Hash)
-      messages.keys.map(&:to_s)
-    else
-      [User.current.language]
-    end
-  end
-
   # { date: { formats: { defaults: '%m/%d/%Y'}}} to {'date.formats.defaults' => '%m/%d/%Y'}
   def self.flatten_hash(hash=nil)
     return hash unless hash.is_a?(Hash)

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -65,11 +65,7 @@ class CustomMessageSetting < Setting
 
   def toggle_enabled!
     self.value = self.value.merge({enabled: (!self.enabled?).to_s})
-
-    if result = self.save
-      MessageCustomize::Locale.reload!(self.using_languages)
-    end
-    result
+    self.save
   end
 
   def using_languages

--- a/app/models/custom_message_setting.rb
+++ b/app/models/custom_message_setting.rb
@@ -18,6 +18,18 @@ class CustomMessageSetting < Setting
     messages || {}
   end
 
+  def custom_messages_with_timestamp(lang=nil, check_enabled=false)
+    messages = self.custom_messages(lang, check_enabled)
+    messages.merge({'redmine_message_customize_timestamp' => self.try(:updated_on).to_i.to_s})
+  end
+
+  def latest_messages_applied?(lang)
+    return true if self.new_record?
+
+    redmine_message_customize_timestamp = I18n.backend.send(:translations)[:"#{lang}"][:redmine_message_customize_timestamp]
+    redmine_message_customize_timestamp == self.updated_on.to_i.to_s
+  end
+
   def custom_messages_to_flatten_hash(lang=nil)
     self.class.flatten_hash(custom_messages(lang))
   end

--- a/config/locales/custom_messages/ar.rb
+++ b/config/locales/custom_messages/ar.rb
@@ -1,1 +1,1 @@
-{ ar: CustomMessageSetting.find_or_default.custom_messages('ar', true) }
+{ ar: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ar', true) }

--- a/config/locales/custom_messages/ar.rb
+++ b/config/locales/custom_messages/ar.rb
@@ -1,1 +1,1 @@
-{ ar: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ar', true) }
+{ ar: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ar') }

--- a/config/locales/custom_messages/az.rb
+++ b/config/locales/custom_messages/az.rb
@@ -1,1 +1,1 @@
-{ az: CustomMessageSetting.find_or_default.custom_messages('az', true) }
+{ az: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('az', true) }

--- a/config/locales/custom_messages/az.rb
+++ b/config/locales/custom_messages/az.rb
@@ -1,1 +1,1 @@
-{ az: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('az', true) }
+{ az: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('az') }

--- a/config/locales/custom_messages/bg.rb
+++ b/config/locales/custom_messages/bg.rb
@@ -1,1 +1,1 @@
-{ bg: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bg', true) }
+{ bg: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bg') }

--- a/config/locales/custom_messages/bg.rb
+++ b/config/locales/custom_messages/bg.rb
@@ -1,1 +1,1 @@
-{ bg: CustomMessageSetting.find_or_default.custom_messages('bg', true) }
+{ bg: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bg', true) }

--- a/config/locales/custom_messages/bs.rb
+++ b/config/locales/custom_messages/bs.rb
@@ -1,1 +1,1 @@
-{ bs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bs', true) }
+{ bs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bs') }

--- a/config/locales/custom_messages/bs.rb
+++ b/config/locales/custom_messages/bs.rb
@@ -1,1 +1,1 @@
-{ bs: CustomMessageSetting.find_or_default.custom_messages('bs', true) }
+{ bs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('bs', true) }

--- a/config/locales/custom_messages/ca.rb
+++ b/config/locales/custom_messages/ca.rb
@@ -1,1 +1,1 @@
-{ ca: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ca', true) }
+{ ca: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ca') }

--- a/config/locales/custom_messages/ca.rb
+++ b/config/locales/custom_messages/ca.rb
@@ -1,1 +1,1 @@
-{ ca: CustomMessageSetting.find_or_default.custom_messages('ca', true) }
+{ ca: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ca', true) }

--- a/config/locales/custom_messages/cs.rb
+++ b/config/locales/custom_messages/cs.rb
@@ -1,1 +1,1 @@
-{ cs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('cs', true) }
+{ cs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('cs') }

--- a/config/locales/custom_messages/cs.rb
+++ b/config/locales/custom_messages/cs.rb
@@ -1,1 +1,1 @@
-{ cs: CustomMessageSetting.find_or_default.custom_messages('cs', true) }
+{ cs: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('cs', true) }

--- a/config/locales/custom_messages/da.rb
+++ b/config/locales/custom_messages/da.rb
@@ -1,1 +1,1 @@
-{ da: CustomMessageSetting.find_or_default.custom_messages('da', true) }
+{ da: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('da', true) }

--- a/config/locales/custom_messages/da.rb
+++ b/config/locales/custom_messages/da.rb
@@ -1,1 +1,1 @@
-{ da: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('da', true) }
+{ da: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('da') }

--- a/config/locales/custom_messages/de.rb
+++ b/config/locales/custom_messages/de.rb
@@ -1,1 +1,1 @@
-{ de: CustomMessageSetting.find_or_default.custom_messages('de', true) }
+{ de: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('de', true) }

--- a/config/locales/custom_messages/de.rb
+++ b/config/locales/custom_messages/de.rb
@@ -1,1 +1,1 @@
-{ de: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('de', true) }
+{ de: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('de') }

--- a/config/locales/custom_messages/el.rb
+++ b/config/locales/custom_messages/el.rb
@@ -1,1 +1,1 @@
-{ el: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('el', true) }
+{ el: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('el') }

--- a/config/locales/custom_messages/el.rb
+++ b/config/locales/custom_messages/el.rb
@@ -1,1 +1,1 @@
-{ el: CustomMessageSetting.find_or_default.custom_messages('el', true) }
+{ el: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('el', true) }

--- a/config/locales/custom_messages/en-GB.rb
+++ b/config/locales/custom_messages/en-GB.rb
@@ -1,1 +1,1 @@
-{ "en-GB": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en-GB', true) }
+{ "en-GB": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en-GB') }

--- a/config/locales/custom_messages/en-GB.rb
+++ b/config/locales/custom_messages/en-GB.rb
@@ -1,1 +1,1 @@
-{ "en-GB": CustomMessageSetting.find_or_default.custom_messages('en-GB', true) }
+{ "en-GB": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en-GB', true) }

--- a/config/locales/custom_messages/en.rb
+++ b/config/locales/custom_messages/en.rb
@@ -1,1 +1,1 @@
-{ en: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en', true) }
+{ en: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en') }

--- a/config/locales/custom_messages/en.rb
+++ b/config/locales/custom_messages/en.rb
@@ -1,1 +1,1 @@
-{ en: CustomMessageSetting.find_or_default.custom_messages('en', true) }
+{ en: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('en', true) }

--- a/config/locales/custom_messages/es-PA.rb
+++ b/config/locales/custom_messages/es-PA.rb
@@ -1,1 +1,1 @@
-{ "es-PA": CustomMessageSetting.find_or_default.custom_messages('es-PA', true) }
+{ "es-PA": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es-PA', true) }

--- a/config/locales/custom_messages/es-PA.rb
+++ b/config/locales/custom_messages/es-PA.rb
@@ -1,1 +1,1 @@
-{ "es-PA": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es-PA', true) }
+{ "es-PA": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es-PA') }

--- a/config/locales/custom_messages/es.rb
+++ b/config/locales/custom_messages/es.rb
@@ -1,1 +1,1 @@
-{ es: CustomMessageSetting.find_or_default.custom_messages('es', true) }
+{ es: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es', true) }

--- a/config/locales/custom_messages/es.rb
+++ b/config/locales/custom_messages/es.rb
@@ -1,1 +1,1 @@
-{ es: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es', true) }
+{ es: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('es') }

--- a/config/locales/custom_messages/et.rb
+++ b/config/locales/custom_messages/et.rb
@@ -1,1 +1,1 @@
-{ et: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('et', true) }
+{ et: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('et') }

--- a/config/locales/custom_messages/et.rb
+++ b/config/locales/custom_messages/et.rb
@@ -1,1 +1,1 @@
-{ et: CustomMessageSetting.find_or_default.custom_messages('et', true) }
+{ et: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('et', true) }

--- a/config/locales/custom_messages/eu.rb
+++ b/config/locales/custom_messages/eu.rb
@@ -1,1 +1,1 @@
-{ eu: CustomMessageSetting.find_or_default.custom_messages('eu', true) }
+{ eu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('eu', true) }

--- a/config/locales/custom_messages/eu.rb
+++ b/config/locales/custom_messages/eu.rb
@@ -1,1 +1,1 @@
-{ eu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('eu', true) }
+{ eu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('eu') }

--- a/config/locales/custom_messages/fa.rb
+++ b/config/locales/custom_messages/fa.rb
@@ -1,1 +1,1 @@
-{ fa: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fa', true) }
+{ fa: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fa') }

--- a/config/locales/custom_messages/fa.rb
+++ b/config/locales/custom_messages/fa.rb
@@ -1,1 +1,1 @@
-{ fa: CustomMessageSetting.find_or_default.custom_messages('fa', true) }
+{ fa: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fa', true) }

--- a/config/locales/custom_messages/fi.rb
+++ b/config/locales/custom_messages/fi.rb
@@ -1,1 +1,1 @@
-{ fi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fi', true) }
+{ fi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fi') }

--- a/config/locales/custom_messages/fi.rb
+++ b/config/locales/custom_messages/fi.rb
@@ -1,1 +1,1 @@
-{ fi: CustomMessageSetting.find_or_default.custom_messages('fi', true) }
+{ fi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fi', true) }

--- a/config/locales/custom_messages/fr.rb
+++ b/config/locales/custom_messages/fr.rb
@@ -1,1 +1,1 @@
-{ fr: CustomMessageSetting.find_or_default.custom_messages('fr', true) }
+{ fr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fr', true) }

--- a/config/locales/custom_messages/fr.rb
+++ b/config/locales/custom_messages/fr.rb
@@ -1,1 +1,1 @@
-{ fr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fr', true) }
+{ fr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('fr') }

--- a/config/locales/custom_messages/gl.rb
+++ b/config/locales/custom_messages/gl.rb
@@ -1,1 +1,1 @@
-{ gl: CustomMessageSetting.find_or_default.custom_messages('gl', true) }
+{ gl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('gl', true) }

--- a/config/locales/custom_messages/gl.rb
+++ b/config/locales/custom_messages/gl.rb
@@ -1,1 +1,1 @@
-{ gl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('gl', true) }
+{ gl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('gl') }

--- a/config/locales/custom_messages/he.rb
+++ b/config/locales/custom_messages/he.rb
@@ -1,1 +1,1 @@
-{ he: CustomMessageSetting.find_or_default.custom_messages('he', true) }
+{ he: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('he', true) }

--- a/config/locales/custom_messages/he.rb
+++ b/config/locales/custom_messages/he.rb
@@ -1,1 +1,1 @@
-{ he: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('he', true) }
+{ he: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('he') }

--- a/config/locales/custom_messages/hr.rb
+++ b/config/locales/custom_messages/hr.rb
@@ -1,1 +1,1 @@
-{ hr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hr', true) }
+{ hr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hr') }

--- a/config/locales/custom_messages/hr.rb
+++ b/config/locales/custom_messages/hr.rb
@@ -1,1 +1,1 @@
-{ hr: CustomMessageSetting.find_or_default.custom_messages('hr', true) }
+{ hr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hr', true) }

--- a/config/locales/custom_messages/hu.rb
+++ b/config/locales/custom_messages/hu.rb
@@ -1,1 +1,1 @@
-{ hu: CustomMessageSetting.find_or_default.custom_messages('hu', true) }
+{ hu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hu', true) }

--- a/config/locales/custom_messages/hu.rb
+++ b/config/locales/custom_messages/hu.rb
@@ -1,1 +1,1 @@
-{ hu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hu', true) }
+{ hu: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('hu') }

--- a/config/locales/custom_messages/id.rb
+++ b/config/locales/custom_messages/id.rb
@@ -1,1 +1,1 @@
-{ id: CustomMessageSetting.find_or_default.custom_messages('id', true) }
+{ id: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('id', true) }

--- a/config/locales/custom_messages/id.rb
+++ b/config/locales/custom_messages/id.rb
@@ -1,1 +1,1 @@
-{ id: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('id', true) }
+{ id: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('id') }

--- a/config/locales/custom_messages/it.rb
+++ b/config/locales/custom_messages/it.rb
@@ -1,1 +1,1 @@
-{ it: CustomMessageSetting.find_or_default.custom_messages('it', true) }
+{ it: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('it', true) }

--- a/config/locales/custom_messages/it.rb
+++ b/config/locales/custom_messages/it.rb
@@ -1,1 +1,1 @@
-{ it: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('it', true) }
+{ it: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('it') }

--- a/config/locales/custom_messages/ja.rb
+++ b/config/locales/custom_messages/ja.rb
@@ -1,1 +1,1 @@
-{ ja: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ja', true) }
+{ ja: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ja') }

--- a/config/locales/custom_messages/ja.rb
+++ b/config/locales/custom_messages/ja.rb
@@ -1,1 +1,1 @@
-{ ja: CustomMessageSetting.find_or_default.custom_messages('ja', true) }
+{ ja: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ja', true) }

--- a/config/locales/custom_messages/ko.rb
+++ b/config/locales/custom_messages/ko.rb
@@ -1,1 +1,1 @@
-{ ko: CustomMessageSetting.find_or_default.custom_messages('ko', true) }
+{ ko: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ko', true) }

--- a/config/locales/custom_messages/ko.rb
+++ b/config/locales/custom_messages/ko.rb
@@ -1,1 +1,1 @@
-{ ko: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ko', true) }
+{ ko: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ko') }

--- a/config/locales/custom_messages/lt.rb
+++ b/config/locales/custom_messages/lt.rb
@@ -1,1 +1,1 @@
-{ lt: CustomMessageSetting.find_or_default.custom_messages('lt', true) }
+{ lt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lt', true) }

--- a/config/locales/custom_messages/lt.rb
+++ b/config/locales/custom_messages/lt.rb
@@ -1,1 +1,1 @@
-{ lt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lt', true) }
+{ lt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lt') }

--- a/config/locales/custom_messages/lv.rb
+++ b/config/locales/custom_messages/lv.rb
@@ -1,1 +1,1 @@
-{ lv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lv', true) }
+{ lv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lv') }

--- a/config/locales/custom_messages/lv.rb
+++ b/config/locales/custom_messages/lv.rb
@@ -1,1 +1,1 @@
-{ lv: CustomMessageSetting.find_or_default.custom_messages('lv', true) }
+{ lv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('lv', true) }

--- a/config/locales/custom_messages/mk.rb
+++ b/config/locales/custom_messages/mk.rb
@@ -1,1 +1,1 @@
-{ mk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mk', true) }
+{ mk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mk') }

--- a/config/locales/custom_messages/mk.rb
+++ b/config/locales/custom_messages/mk.rb
@@ -1,1 +1,1 @@
-{ mk: CustomMessageSetting.find_or_default.custom_messages('mk', true) }
+{ mk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mk', true) }

--- a/config/locales/custom_messages/mn.rb
+++ b/config/locales/custom_messages/mn.rb
@@ -1,1 +1,1 @@
-{ mn: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mn', true) }
+{ mn: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mn') }

--- a/config/locales/custom_messages/mn.rb
+++ b/config/locales/custom_messages/mn.rb
@@ -1,1 +1,1 @@
-{ mn: CustomMessageSetting.find_or_default.custom_messages('mn', true) }
+{ mn: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('mn', true) }

--- a/config/locales/custom_messages/nl.rb
+++ b/config/locales/custom_messages/nl.rb
@@ -1,1 +1,1 @@
-{ nl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('nl', true) }
+{ nl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('nl') }

--- a/config/locales/custom_messages/nl.rb
+++ b/config/locales/custom_messages/nl.rb
@@ -1,1 +1,1 @@
-{ nl: CustomMessageSetting.find_or_default.custom_messages('nl', true) }
+{ nl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('nl', true) }

--- a/config/locales/custom_messages/no.rb
+++ b/config/locales/custom_messages/no.rb
@@ -1,1 +1,1 @@
-{ no: CustomMessageSetting.find_or_default.custom_messages('no', true) }
+{ no: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('no', true) }

--- a/config/locales/custom_messages/no.rb
+++ b/config/locales/custom_messages/no.rb
@@ -1,1 +1,1 @@
-{ no: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('no', true) }
+{ no: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('no') }

--- a/config/locales/custom_messages/pl.rb
+++ b/config/locales/custom_messages/pl.rb
@@ -1,1 +1,1 @@
-{ pl: CustomMessageSetting.find_or_default.custom_messages('pl', true) }
+{ pl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pl', true) }

--- a/config/locales/custom_messages/pl.rb
+++ b/config/locales/custom_messages/pl.rb
@@ -1,1 +1,1 @@
-{ pl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pl', true) }
+{ pl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pl') }

--- a/config/locales/custom_messages/pt-BR.rb
+++ b/config/locales/custom_messages/pt-BR.rb
@@ -1,1 +1,1 @@
-{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt-BR', true) }
+{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt-BR') }

--- a/config/locales/custom_messages/pt-BR.rb
+++ b/config/locales/custom_messages/pt-BR.rb
@@ -1,1 +1,1 @@
-{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages('pt-BR', true) }
+{ "pt-BR": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt-BR', true) }

--- a/config/locales/custom_messages/pt.rb
+++ b/config/locales/custom_messages/pt.rb
@@ -1,1 +1,1 @@
-{ pt: CustomMessageSetting.find_or_default.custom_messages('pt', true) }
+{ pt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt', true) }

--- a/config/locales/custom_messages/pt.rb
+++ b/config/locales/custom_messages/pt.rb
@@ -1,1 +1,1 @@
-{ pt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt', true) }
+{ pt: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('pt') }

--- a/config/locales/custom_messages/ro.rb
+++ b/config/locales/custom_messages/ro.rb
@@ -1,1 +1,1 @@
-{ ro: CustomMessageSetting.find_or_default.custom_messages('ro', true) }
+{ ro: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ro', true) }

--- a/config/locales/custom_messages/ro.rb
+++ b/config/locales/custom_messages/ro.rb
@@ -1,1 +1,1 @@
-{ ro: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ro', true) }
+{ ro: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ro') }

--- a/config/locales/custom_messages/ru.rb
+++ b/config/locales/custom_messages/ru.rb
@@ -1,1 +1,1 @@
-{ ru: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ru', true) }
+{ ru: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ru') }

--- a/config/locales/custom_messages/ru.rb
+++ b/config/locales/custom_messages/ru.rb
@@ -1,1 +1,1 @@
-{ ru: CustomMessageSetting.find_or_default.custom_messages('ru', true) }
+{ ru: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('ru', true) }

--- a/config/locales/custom_messages/sk.rb
+++ b/config/locales/custom_messages/sk.rb
@@ -1,1 +1,1 @@
-{ sk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sk', true) }
+{ sk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sk') }

--- a/config/locales/custom_messages/sk.rb
+++ b/config/locales/custom_messages/sk.rb
@@ -1,1 +1,1 @@
-{ sk: CustomMessageSetting.find_or_default.custom_messages('sk', true) }
+{ sk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sk', true) }

--- a/config/locales/custom_messages/sl.rb
+++ b/config/locales/custom_messages/sl.rb
@@ -1,1 +1,1 @@
-{ sl: CustomMessageSetting.find_or_default.custom_messages('sl', true) }
+{ sl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sl', true) }

--- a/config/locales/custom_messages/sl.rb
+++ b/config/locales/custom_messages/sl.rb
@@ -1,1 +1,1 @@
-{ sl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sl', true) }
+{ sl: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sl') }

--- a/config/locales/custom_messages/sq.rb
+++ b/config/locales/custom_messages/sq.rb
@@ -1,1 +1,1 @@
-{ sq: CustomMessageSetting.find_or_default.custom_messages('sq', true) }
+{ sq: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sq', true) }

--- a/config/locales/custom_messages/sq.rb
+++ b/config/locales/custom_messages/sq.rb
@@ -1,1 +1,1 @@
-{ sq: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sq', true) }
+{ sq: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sq') }

--- a/config/locales/custom_messages/sr-YU.rb
+++ b/config/locales/custom_messages/sr-YU.rb
@@ -1,1 +1,1 @@
-{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages('sr-YU', true) }
+{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr-YU', true) }

--- a/config/locales/custom_messages/sr-YU.rb
+++ b/config/locales/custom_messages/sr-YU.rb
@@ -1,1 +1,1 @@
-{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr-YU', true) }
+{ "sr-YU": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr-YU') }

--- a/config/locales/custom_messages/sr.rb
+++ b/config/locales/custom_messages/sr.rb
@@ -1,1 +1,1 @@
-{ sr: CustomMessageSetting.find_or_default.custom_messages('sr', true) }
+{ sr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr', true) }

--- a/config/locales/custom_messages/sr.rb
+++ b/config/locales/custom_messages/sr.rb
@@ -1,1 +1,1 @@
-{ sr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr', true) }
+{ sr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sr') }

--- a/config/locales/custom_messages/sv.rb
+++ b/config/locales/custom_messages/sv.rb
@@ -1,1 +1,1 @@
-{ sv: CustomMessageSetting.find_or_default.custom_messages('sv', true) }
+{ sv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sv', true) }

--- a/config/locales/custom_messages/sv.rb
+++ b/config/locales/custom_messages/sv.rb
@@ -1,1 +1,1 @@
-{ sv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sv', true) }
+{ sv: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('sv') }

--- a/config/locales/custom_messages/th.rb
+++ b/config/locales/custom_messages/th.rb
@@ -1,1 +1,1 @@
-{ th: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('th', true) }
+{ th: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('th') }

--- a/config/locales/custom_messages/th.rb
+++ b/config/locales/custom_messages/th.rb
@@ -1,1 +1,1 @@
-{ th: CustomMessageSetting.find_or_default.custom_messages('th', true) }
+{ th: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('th', true) }

--- a/config/locales/custom_messages/tr.rb
+++ b/config/locales/custom_messages/tr.rb
@@ -1,1 +1,1 @@
-{ tr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('tr', true) }
+{ tr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('tr') }

--- a/config/locales/custom_messages/tr.rb
+++ b/config/locales/custom_messages/tr.rb
@@ -1,1 +1,1 @@
-{ tr: CustomMessageSetting.find_or_default.custom_messages('tr', true) }
+{ tr: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('tr', true) }

--- a/config/locales/custom_messages/uk.rb
+++ b/config/locales/custom_messages/uk.rb
@@ -1,1 +1,1 @@
-{ uk: CustomMessageSetting.find_or_default.custom_messages('uk', true) }
+{ uk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('uk', true) }

--- a/config/locales/custom_messages/uk.rb
+++ b/config/locales/custom_messages/uk.rb
@@ -1,1 +1,1 @@
-{ uk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('uk', true) }
+{ uk: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('uk') }

--- a/config/locales/custom_messages/vi.rb
+++ b/config/locales/custom_messages/vi.rb
@@ -1,1 +1,1 @@
-{ vi: CustomMessageSetting.find_or_default.custom_messages('vi', true) }
+{ vi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('vi', true) }

--- a/config/locales/custom_messages/vi.rb
+++ b/config/locales/custom_messages/vi.rb
@@ -1,1 +1,1 @@
-{ vi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('vi', true) }
+{ vi: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('vi') }

--- a/config/locales/custom_messages/zh-TW.rb
+++ b/config/locales/custom_messages/zh-TW.rb
@@ -1,1 +1,1 @@
-{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages('zh-TW', true) }
+{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh-TW', true) }

--- a/config/locales/custom_messages/zh-TW.rb
+++ b/config/locales/custom_messages/zh-TW.rb
@@ -1,1 +1,1 @@
-{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh-TW', true) }
+{ "zh-TW": CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh-TW') }

--- a/config/locales/custom_messages/zh.rb
+++ b/config/locales/custom_messages/zh.rb
@@ -1,1 +1,1 @@
-{ zh: CustomMessageSetting.find_or_default.custom_messages('zh', true) }
+{ zh: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh', true) }

--- a/config/locales/custom_messages/zh.rb
+++ b/config/locales/custom_messages/zh.rb
@@ -1,1 +1,1 @@
-{ zh: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh', true) }
+{ zh: CustomMessageSetting.find_or_default.custom_messages_with_timestamp('zh') }

--- a/init.rb
+++ b/init.rb
@@ -2,6 +2,7 @@
 
 require File.expand_path('../lib/message_customize/locale', __FILE__)
 require File.expand_path('../lib/message_customize/hooks', __FILE__)
+require File.expand_path('../lib/message_customize/application_controller_patch', __FILE__)
 
 p = Redmine::Plugin.register :redmine_message_customize do
   name 'Redmine message customize plugin'

--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -13,11 +13,16 @@ module MessageCustomize
 
     module InstanceMethod
       def reload_customize_messages
-        language = User.current.language.presence || Setting.default_language
         custom_message_setting = CustomMessageSetting.find_or_default
-        return if custom_message_setting.latest_messages_applied?(language)
+        return if custom_message_setting.latest_messages_applied?(current_user_language)
 
-        MessageCustomize::Locale.reload!([language])
+        MessageCustomize::Locale.reload!([current_user_language])
+      end
+
+      private
+
+      def current_user_language
+        User.current.language.presence || Setting.default_language
       end
     end
   end

--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require 'application_controller'
+
+module MessageCustomize
+  module ApplicationControllerPatch
+    def self.included(base)
+      base.send(:include, InstanceMethod)
+      base.class_eval do
+        before_action :reload_customize_messages
+      end
+    end
+
+    module InstanceMethod
+      def reload_customize_messages
+        custom_message_setting = CustomMessageSetting.find_or_default
+        return if custom_message_setting.new_record?
+
+        language = User.current.language.presence || Setting.default_language
+        return if custom_message_setting.latest_messages_applied?(language)
+
+        MessageCustomize::Locale.reload!([language])
+      end
+    end
+  end
+end
+
+ApplicationController.include(MessageCustomize::ApplicationControllerPatch)

--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -14,7 +14,6 @@ module MessageCustomize
     module InstanceMethod
       def reload_customize_messages
         custom_message_setting = CustomMessageSetting.find_or_default
-        return if custom_message_setting.new_record?
 
         language = User.current.language.presence || Setting.default_language
         return if custom_message_setting.latest_messages_applied?(language)

--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -13,9 +13,8 @@ module MessageCustomize
 
     module InstanceMethod
       def reload_customize_messages
-        custom_message_setting = CustomMessageSetting.find_or_default
-
         language = User.current.language.presence || Setting.default_language
+        custom_message_setting = CustomMessageSetting.find_or_default
         return if custom_message_setting.latest_messages_applied?(language)
 
         MessageCustomize::Locale.reload!([language])

--- a/test/fixtures/custom_message_settings.yml
+++ b/test/fixtures/custom_message_settings.yml
@@ -5,4 +5,4 @@ one:
     custom_messages: { en: { label_home: 'Home1' }, ja: { label_home: 'Home2' }},
     enabled: 'true'
     }
-  updated_on: '2022-01-01 00:00'
+  updated_on: '2022-01-01 00:00Z'

--- a/test/fixtures/custom_message_settings.yml
+++ b/test/fixtures/custom_message_settings.yml
@@ -5,3 +5,4 @@ one:
     custom_messages: { en: { label_home: 'Home1' }, ja: { label_home: 'Home2' }},
     enabled: 'true'
     }
+  updated_on: '2022-01-01 00:00'

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -50,6 +50,7 @@ class CustomMessageSettingsControllerTest < defined?(Redmine::ControllerTest) ? 
 
     get :update, params: { settings: {'custom_messages'=>{'label_home' => 'Home3'}}, lang: 'en', tab: 'normal' }
 
+    MessageCustomize::Locale.reload!('en')
     assert_equal 'Home3', l(:label_home)
     assert_redirected_to edit_custom_message_settings_path(lang: 'en', tab: 'normal')
     assert_equal l(:notice_successful_update), flash[:notice]
@@ -59,6 +60,7 @@ class CustomMessageSettingsControllerTest < defined?(Redmine::ControllerTest) ? 
 
     get :update, params: { settings: {'custom_messages_yaml'=>"---\nen:\n  label_home: Home3"}, tab: 'yaml' }
 
+    MessageCustomize::Locale.reload!('en')
     assert_equal 'Home3', l(:label_home)
     assert_redirected_to edit_custom_message_settings_path(lang: 'en', tab: 'yaml')
     assert_equal l(:notice_successful_update), flash[:notice]

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -1,13 +1,13 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class CustomMessageSettingsControllerTest < defined?(Redmine::ControllerTest) ? Redmine::ControllerTest : ActionController::TestCase
-  fixtures :custom_message_settings, :users
+  fixtures :users, :email_addresses, :roles, :custom_message_settings
   include Redmine::I18n
   prepend ::RailsKwargsTesting::ControllerMethods if defined?(RailsKwargsTesting)
 
   def setup
     @request.session[:user_id] = 1 # admin
-    MessageCustomize::Locale.reload!('en')
+    MessageCustomize::Locale.reload!(['en', 'ja'])
     Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 

--- a/test/functional/custom_message_settings_controller_test.rb
+++ b/test/functional/custom_message_settings_controller_test.rb
@@ -8,6 +8,7 @@ class CustomMessageSettingsControllerTest < defined?(Redmine::ControllerTest) ? 
   def setup
     @request.session[:user_id] = 1 # admin
     MessageCustomize::Locale.reload!(['en', 'ja'])
+    set_language_if_valid 'en'
     Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 

--- a/test/integration/application_controller_patch_test.rb
+++ b/test/integration/application_controller_patch_test.rb
@@ -1,0 +1,72 @@
+# frozen_string_literal: true
+
+require File.expand_path('../../test_helper', __FILE__)
+
+class ApplicationControllerPatchTest < Redmine::IntegrationTest
+  fixtures :users, :email_addresses, :roles, :custom_message_settings
+
+  def setup
+    MessageCustomize::Locale.reload!(['ja', 'en'])
+    Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
+  end
+
+  def test_reload_if_messages_are_not_latest
+    User.find_by_login('admin').update(language: 'ja')
+    log_user('admin', 'admin')
+    custom_message_setting = CustomMessageSetting.find_or_default
+
+    # 値が書き換わっただけでは用語は置き換わらない(MessageCustomize::Locale.reload!の実行が必要)
+    custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'ja')
+    assert_equal 'Home2', I18n.backend.send(:translations)[:ja][:label_home]
+    assert_equal '1640995200', I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+
+    # ApplicationControllerのbefore_actionによって、redmine_message_customize_timestampの値を見て最新かが判断される
+    # get '/issues'は最新じゃない状態でのリクエストのためMessageCustomize::Locale.reload!が実行されること
+    get '/issues'
+    assert_equal 'Changed home', I18n.backend.send(:translations)[:ja][:label_home]
+    assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+  end
+
+  def test_reload_if_user_language_is_auto_and_default_language_messages_are_not_latest
+    # User.currentのlanguageが''(auto)でもSetting.default_languageを元に用語の最新化を行うこと
+    User.find_by_login('admin').update(language: '')
+    Setting.default_language = 'ja'
+    log_user('admin', 'admin')
+    custom_message_setting = CustomMessageSetting.find_or_default
+
+    custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'ja')
+    assert_equal 'Home2', I18n.backend.send(:translations)[:ja][:label_home]
+    assert_equal '1640995200', I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+
+    get '/issues'
+    assert_equal 'Changed home', I18n.backend.send(:translations)[:ja][:label_home]
+    assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+  end
+
+  def test_reload_if_messages_are_in_different_language_than_the_language_in_which_you_customized_the_message
+    # メッセージをカスタマイズした言語とは別の言語を利用している場合もreloadすること
+    User.find_by_login('admin').update(language: 'en')
+    log_user('admin', 'admin')
+    custom_message_setting = CustomMessageSetting.find_or_default
+
+    custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'ja')
+    assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
+    assert_equal '1640995200', I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
+
+    get '/issues'
+    assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home] # 変わらない
+    assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
+  end
+
+  def test_dont_reload_if_messages_are_latest
+    MessageCustomize::Locale.expects(:reload!).never
+    get '/issues'
+  end
+
+  def test_dont_reload_if_customize_message_setting_is_not_saved
+    CustomMessageSetting.find_or_default.destroy
+
+    MessageCustomize::Locale.expects(:reload!).never
+    get '/issues'
+  end
+end

--- a/test/integration/application_controller_patch_test.rb
+++ b/test/integration/application_controller_patch_test.rb
@@ -11,26 +11,24 @@ class ApplicationControllerPatchTest < Redmine::IntegrationTest
   end
 
   def test_reload_if_messages_are_not_latest
-    User.find_by_login('admin').update(language: 'ja')
     log_user('admin', 'admin')
     custom_message_setting = CustomMessageSetting.find_or_default
 
     # 値が書き換わっただけでは用語は置き換わらない(MessageCustomize::Locale.reload!の実行が必要)
-    custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'ja')
-    assert_equal 'Home2', I18n.backend.send(:translations)[:ja][:label_home]
-    assert_equal '1640995200', I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+    custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'en')
+    assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
+    assert_equal '1640995200', I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
 
     # ApplicationControllerのbefore_actionによって、redmine_message_customize_timestampの値を見て最新かが判断される
     # get '/issues'は最新じゃない状態でのリクエストのためMessageCustomize::Locale.reload!が実行されること
     get '/issues'
-    assert_equal 'Changed home', I18n.backend.send(:translations)[:ja][:label_home]
-    assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
+    assert_equal 'Changed home', I18n.backend.send(:translations)[:en][:label_home]
+    assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
   end
 
   def test_reload_if_user_language_is_auto_and_default_language_messages_are_not_latest
     # User.currentのlanguageが''(auto)でもSetting.default_languageを元に用語の最新化を行うこと
     User.find_by_login('admin').update(language: '')
-    Setting.default_language = 'ja'
     log_user('admin', 'admin')
     custom_message_setting = CustomMessageSetting.find_or_default
 
@@ -38,7 +36,9 @@ class ApplicationControllerPatchTest < Redmine::IntegrationTest
     assert_equal 'Home2', I18n.backend.send(:translations)[:ja][:label_home]
     assert_equal '1640995200', I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
 
-    get '/issues'
+    with_settings :default_language => 'ja' do
+      get '/issues'
+    end
     assert_equal 'Changed home', I18n.backend.send(:translations)[:ja][:label_home]
     assert_equal custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:ja][:redmine_message_customize_timestamp]
   end

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -58,7 +58,6 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
   end
 
   def test_custom_messages_with_timestamp
-    assert_equal @custom_message_setting.value['custom_messages'].merge({'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp
     assert_equal ({'label_home' => 'Home1', 'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp('en')
     assert_equal ({'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp('foo')
   end

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -55,6 +55,30 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal ({}), @custom_message_setting.custom_messages('foo')
   end
 
+  def test_custom_messages_with_timestamp
+    assert_equal @custom_message_setting.value['custom_messages'].merge({'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp
+    assert_equal ({'label_home' => 'Home1', 'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp('en')
+    assert_equal ({'redmine_message_customize_timestamp' => @custom_message_setting.updated_on.to_i.to_s}), @custom_message_setting.custom_messages_with_timestamp('foo')
+  end
+
+  def test_latest_messages_applied_should_return_true_if_new_record
+    @custom_message_setting.destroy
+    custom_message_setting = CustomMessageSetting.find_or_default
+    assert custom_message_setting.latest_messages_applied?('en')
+  end
+
+  def test_latest_messages_applied_should_return_true_if_redmine_message_customize_timestamp_equal_updated_on
+    assert_equal @custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
+    assert @custom_message_setting.latest_messages_applied?('en')
+  end
+
+  def test_latest_messages_applied_should_return_true_if_redmine_message_customize_timestamp_not_equal_updated_on
+    @custom_message_setting.update_with_custom_messages({'label_home' => 'Changed home'}, 'en')
+
+    assert_not_equal @custom_message_setting.updated_on.to_i.to_s, I18n.backend.send(:translations)[:en][:redmine_message_customize_timestamp]
+    assert_not @custom_message_setting.latest_messages_applied?('en')
+  end
+
   def test_custom_messages_with_check_enabled
     assert @custom_message_setting.enabled?
     assert_equal ({'label_home' => 'Home1'}), @custom_message_setting.custom_messages('en', true)

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -1,12 +1,13 @@
 require File.dirname(__FILE__) + '/../test_helper'
 
 class CustomMessageSettingTest < ActiveSupport::TestCase
-  fixtures :custom_message_settings
+  fixtures :users, :email_addresses, :roles, :custom_message_settings
   include Redmine::I18n
 
   def setup
+    User.current = User.find_by(login: 'admin')
     @custom_message_setting = CustomMessageSetting.find(1)
-    MessageCustomize::Locale.reload!('en')
+    MessageCustomize::Locale.reload!(['en', 'ja'])
     Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -8,6 +8,7 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     User.current = User.find_by(login: 'admin')
     @custom_message_setting = CustomMessageSetting.find(1)
     MessageCustomize::Locale.reload!(['en', 'ja'])
+    set_language_if_valid 'en'
     Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
   end
 

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -134,10 +134,6 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
     assert_equal 'Home1', l(:label_home)
   end
 
-  def test_using_languages
-    assert_equal ['en', 'ja'], @custom_message_setting.using_languages
-  end
-
   def test_flatten_hash_should_return_hash_with_flat_keys
     flatten_hash = CustomMessageSetting.flatten_hash({time: {am: 'foo'}})
     assert_equal ({:'time.am' => 'foo'}), flatten_hash

--- a/test/unit/custom_message_setting_test.rb
+++ b/test/unit/custom_message_setting_test.rb
@@ -124,10 +124,12 @@ class CustomMessageSettingTest < ActiveSupport::TestCase
 
     @custom_message_setting.toggle_enabled!
     assert_not @custom_message_setting.enabled?
+    MessageCustomize::Locale.reload!('en')
     assert_equal 'Home', l(:label_home)
 
     @custom_message_setting.toggle_enabled!
     assert @custom_message_setting.enabled?
+    MessageCustomize::Locale.reload!('en')
     assert_equal 'Home1', l(:label_home)
   end
 

--- a/test/unit/lib/message_customize/locale_test.rb
+++ b/test/unit/lib/message_customize/locale_test.rb
@@ -5,7 +5,7 @@ class LocaleTest < ActiveSupport::TestCase
   include Redmine::I18n
 
     def setup
-      MessageCustomize::Locale.reload!('en')
+      MessageCustomize::Locale.reload!(['en', 'ja'])
       Rails.application.config.i18n.load_path = (Rails.application.config.i18n.load_path + Dir.glob(Rails.root.join('plugins', 'redmine_message_customize', 'config', 'locales', 'custom_messages', '*.rb'))).uniq
     end
 
@@ -18,7 +18,7 @@ class LocaleTest < ActiveSupport::TestCase
     setting.save
 
     assert_equal 'Home1', I18n.backend.send(:translations)[:en][:label_home]
-    MessageCustomize::Locale.reload!('en')
+    MessageCustomize::Locale.reload!(['en'])
     assert_equal 'Changed home', I18n.backend.send(:translations)[:en][:label_home]
     assert_equal [:en], MessageCustomize::Locale.instance_variable_get(:@available_messages).keys
   end


### PR DESCRIPTION
If requests are distributed between two web servers, such as ALB, there is a problem that only one of them reloads i18n and the terms are not updated.
In order to allow reloading on the other web server as well, we check each request to see if the redmine_message_customize_timestamp is out of date and reload the i18n if it is.
