### PR TITLE
Fixes side effects with application_controller_patch

### DIFF
--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'application_controller'
-
 module MessageCustomize
   module ApplicationControllerPatch
     def self.included(base)


### PR DESCRIPTION
Hi,

I observed some strange side effects with your latest changes by adding the application_controller_patch.rb. 

The problem occurs due to requiring ApplicationController:

```ruby
# frozen_string_literal: true

require 'application_controller' # <-- !Problem is here!

module MessageCustomize
  module ApplicationControllerPatch
   ...
  end
end

```

It only happens under certain circumstances (see [xmera Circle issue 1444](https://circle.xmera.de/issues/1444)).

Since the code runs even without the requirement above I deleted the line  in redmine_message_customize/lib/message_customize/application_controller_patch.rb. 

It would be great when you could merge this change. 

Thank you! :)

Best Regards,

@liaham 

