### PR TITLE
Removes main menu from custom_message_settings_controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .history
+tmp/

--- a/app/controllers/custom_message_settings_controller.rb
+++ b/app/controllers/custom_message_settings_controller.rb
@@ -1,6 +1,7 @@
 class CustomMessageSettingsController < ApplicationController
   layout 'admin'
   menu_item :custom_messages
+  self.main_menu = false
   before_action :require_admin, :set_custom_message_setting, :set_lang
   require_sudo_mode :edit, :update, :toggle_enabled, :default_messages
 


### PR DESCRIPTION
Hi,

This is a consistency improvement. 

Usually the main menu is not displayed in admin area. Therefore, it will be removed with this commit to increase consistency.

The PR adds also the tmp/ dir to .gitignore since it is useful for storing static code analyzer results locally.

Best Regards,
@liaham 