### PR TITLE
Strictly check that the plugin's custom locales are loaded

### DIFF
--- a/lib/message_customize/locale.rb
+++ b/lib/message_customize/locale.rb
@@ -45,7 +45,7 @@ module MessageCustomize
       end
 
       def customizable_plugin_messages?
-        Rails.application.config.i18n.load_path.last.include?('redmine_message_customize')
+        Rails.application.config.i18n.load_path.last.include?('redmine_message_customize/config/locales')
       end
     end
   end


### PR DESCRIPTION
I encountered a failing test, while trying to add a GitHub Actions workflow for automated testing to this repository.
https://github.com/hidakatsuya/redmine_message_customize/actions/runs/9343817907/job/25713963042

The reason the above test fails is that the path of the directory where GitHub Actions runs the workflow is `/home/runner/work/redmine_message_customize`. As a result, the `customizable_plugin_message?` method always returns true.
https://github.com/farend/redmine_message_customize/blob/04df5293d3715745de8f48f322679f39626dce48/lib/message_customize/locale.rb#L47-L49

This pull request addresses and resolves this issue.

I have confirmed the followings:

* Customized message is correctly applied
* All tests pass https://github.com/hidakatsuya/redmine_message_customize/actions/runs/9560644912

The environment in which I confirmed these things is as follows:

```
Environment:
  RedMica version                3.0.0.stable (based on Redmine 5.1.2.devel)
  Ruby version                   3.2.4-p170 (2024-04-23) [aarch64-linux]
  Rails version                  7.1.2
  Environment                    development
  Database adapter               SQLite
  Mailer queue                   ActiveJob::QueueAdapters::AsyncAdapter
  Mailer delivery                smtp
Redmine settings:
  Redmine theme                  Bleuclair (includes JavaScript)
SCM:
  Subversion                     1.14.2
  Mercurial                      6.3.2
  Cvs                            1.12.13
  Bazaar                         3.3.2
  Git                            2.39.2
  Filesystem                     
Plugins:
  redmine_message_customize      1.0.0
```