### PR TITLE
Fix problem with reload not working correctly when auto is set for language

### DIFF
--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -12,15 +12,10 @@ module MessageCustomize
     module InstanceMethod
       def reload_customize_messages
         custom_message_setting = CustomMessageSetting.find_or_default
-        return if custom_message_setting.latest_messages_applied?(current_user_language)
+        # NOTE: ApplicationController#set_localization sets the appropriate language in I18n.locale
+        return if custom_message_setting.latest_messages_applied?(I18n.locale)
 
-        MessageCustomize::Locale.reload!([current_user_language])
-      end
-
-      private
-
-      def current_user_language
-        User.current.language.presence || Setting.default_language
+        MessageCustomize::Locale.reload!([I18n.locale])
       end
     end
   end

--- a/lib/message_customize/application_controller_patch.rb
+++ b/lib/message_customize/application_controller_patch.rb
@@ -12,10 +12,16 @@ module MessageCustomize
     module InstanceMethod
       def reload_customize_messages
         custom_message_setting = CustomMessageSetting.find_or_default
-        # NOTE: ApplicationController#set_localization sets the appropriate language in I18n.locale
-        return if custom_message_setting.latest_messages_applied?(I18n.locale)
+        return if custom_message_setting.latest_messages_applied?(current_user_language)
 
-        MessageCustomize::Locale.reload!([I18n.locale])
+        MessageCustomize::Locale.reload!([current_user_language])
+      end
+
+      private
+
+      # NOTE: ApplicationController#set_localization sets the appropriate language in I18n.locale
+      def current_user_language
+        I18n.locale
       end
     end
   end


### PR DESCRIPTION
**Issue:**
There is a problem where, if a user's language setting is set to auto and the browser's language differs from the default language, the customized settings are not loaded correctly.

**Reproduction steps:**
- Set the user's language preference to auto.
- Ensure that the browser's language is different from the redmine setting's default language.
- Customize the browser language message.
- Observe that the user's customized settings do not load as expected.

Fix:
Use `I18n.locale` instead of `User.current.language.presence || Setting.default_language`.
`I18n.locale` has terms set with appropriate priority by ApplicationController#set_localication and others. https://github.com/redmica/redmica/blob/master/app/controllers/application_controller.rb#L247-L261