### PR TITLE
Change icons to svg

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,9 +12,6 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-3.0'
-            ruby-version: '3.3'
-          - redmine-repository: 'redmica/redmica'
             redmine-version: 'master'
             ruby-version: '3.3'
           - redmine-repository: 'redmine/redmine'

--- a/README.md
+++ b/README.md
@@ -1,20 +1,16 @@
 # redmine_message_customize
 
 This is a plugin for Redmine.  
-This plugin changes the translation of the wording on the screen defined in "config/locales/*.yml" in the admin view.
+This plugin changes the translation of the wording on the screen defined in "config/locales/*.yml" in the admin view.  
+It is available for Redmine 6.0 or later.
 
 ## Install
 
 ```
 $ cd /your/path/redmine
 $ git clone https://github.com/farend/redmine_message_customize.git plugins/redmine_message_customize
-$ # When Redmine 4.1 or lower versions
-$ cp plugins/redmine_message_customize/35_change_load_order_locales.rb config/initializers/35_change_load_order_locales.rb
 $ # redmine restart
 ```
-
-:warning: To customize messages for other plugins in **Redmine 4.1 or lower versions**, redmine_message_customize/35_change_load_order_locales.rb It is necessary to copy the file to redmine/config/initializers.  
-If redmine/config/initializers/35_change_load_order_locales.rb is missing, only non-plugin messages can be customized.
 
 ## Usage
 

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -17,14 +17,14 @@ module CustomMessageSettingsHelper
       content += content_tag(:p) do
         content_tag(:label, k) +
         text_field_tag("settings[custom_messages][#{k}]", v.to_s) +
-        link_to_function('', '$(this).closest("p").remove();', class: 'icon icon-del clear-key-link')
+        link_to_function(sprite_icon('del'), '$(this).closest("p").remove()', class: 'icon icon-del clear-key-link')
       end
     end
     content
   end
 
   def open_default_messages_window_link(lang)
-    link_to l(:label_default_messages),
+    link_to sprite_icon('file', l(:label_default_messages)),
             default_messages_custom_message_settings_path(lang: lang),
             class: 'icon icon-file text-plain',
             onclick: "window.open(this.href,'redmine_message_customize_plugin-default_messages', 'height=800, width=500');return false;",

--- a/app/helpers/custom_message_settings_helper.rb
+++ b/app/helpers/custom_message_settings_helper.rb
@@ -17,7 +17,7 @@ module CustomMessageSettingsHelper
       content += content_tag(:p) do
         content_tag(:label, k) +
         text_field_tag("settings[custom_messages][#{k}]", v.to_s) +
-        link_to_function(sprite_icon('del'), '$(this).closest("p").remove()', class: 'icon icon-del clear-key-link')
+        link_to_function(sprite_icon('del'), '$(this).closest("p").remove()', class: 'icon clear-key-link')
       end
     end
     content
@@ -26,7 +26,7 @@ module CustomMessageSettingsHelper
   def open_default_messages_window_link(lang)
     link_to sprite_icon('file', l(:label_default_messages)),
             default_messages_custom_message_settings_path(lang: lang),
-            class: 'icon icon-file text-plain',
+            class: 'icon text-plain',
             onclick: "window.open(this.href,'redmine_message_customize_plugin-default_messages', 'height=800, width=500');return false;",
             id: 'default-messages-link'
   end

--- a/app/views/custom_message_settings/_messages.html.erb
+++ b/app/views/custom_message_settings/_messages.html.erb
@@ -1,6 +1,6 @@
 <div>
   <%= select_tag 'select-key', available_message_options(@setting, lang), id: 'key-selector' %>
-  <span class='icon icon-help'><%= sprite_icon('help', l(:text_description_of_search_box)) %></span>
+  <span class='icon'><%= sprite_icon('help', l(:text_description_of_search_box)) %></span>
 </div>
 <br>
 <div class='tabular'>
@@ -43,7 +43,7 @@ function AddMessageInputField(key, val){
       name: 'settings[custom_messages][' + key + ']'
     }).appendTo($('#edit-custom-messages .tabular p:first'));
     $('<a>').attr({
-       class: 'icon icon-del clear-key-link',
+       class: 'icon clear-key-link',
        href: '#',
        onclick: '$(this).closest("p").remove(); return false;'
     }).html('<%= sprite_icon('del') %>').appendTo($('#edit-custom-messages .tabular p:first'));

--- a/app/views/custom_message_settings/_messages.html.erb
+++ b/app/views/custom_message_settings/_messages.html.erb
@@ -1,6 +1,6 @@
 <div>
   <%= select_tag 'select-key', available_message_options(@setting, lang), id: 'key-selector' %>
-  <span class='icon icon-help'><%= l(:text_description_of_search_box) %></span>
+  <span class='icon icon-help'><%= sprite_icon('help', l(:text_description_of_search_box)) %></span>
 </div>
 <br>
 <div class='tabular'>
@@ -45,8 +45,8 @@ function AddMessageInputField(key, val){
     $('<a>').attr({
        class: 'icon icon-del clear-key-link',
        href: '#',
-       onclick: '$(this).closest("p").remove();; return false;'
-    }).appendTo($('#edit-custom-messages .tabular p:first'));
+       onclick: '$(this).closest("p").remove(); return false;'
+    }).html('<%= sprite_icon('del') %>').appendTo($('#edit-custom-messages .tabular p:first'));
     $('#key-selector').val('').change();
     $('#key-selector option[value="' + key + '"]').prop("disabled", true).change();
     setSelect2();

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <div class='message-customize-menu contextual'>
-  <%= link_to sprite_icon('settings', (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize))), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon icon-settings' %> /
+  <%= link_to sprite_icon('settings', (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize))), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon' %> /
   <%= open_default_messages_window_link(@lang) %>
 </div>
 

--- a/app/views/custom_message_settings/edit.html.erb
+++ b/app/views/custom_message_settings/edit.html.erb
@@ -8,7 +8,7 @@
 <% end %>
 
 <div class='message-customize-menu contextual'>
-  <%= link_to (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize)), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon icon-settings' %> /
+  <%= link_to sprite_icon('settings', (@setting.enabled? ? l(:label_disable_customize) : l(:label_enable_customize))), toggle_enabled_custom_message_settings_path, method: :post, class: 'icon icon-settings' %> /
   <%= open_default_messages_window_link(@lang) %>
 </div>
 

--- a/init.rb
+++ b/init.rb
@@ -13,7 +13,7 @@ p = Redmine::Plugin.register :redmine_message_customize do
   author_url 'https://github.com/farend'
   settings default: { custom_messages: {} }
   menu :admin_menu, :custom_messages, { controller: 'custom_message_settings', action: 'edit' },
-         caption: :label_custom_messages, html: { class: 'icon icon-edit' }, icon: 'edit'
+         caption: :label_custom_messages, html: { class: 'icon' }, icon: 'edit'
   requires_redmine version_or_higher: '6.0'
 end
 

--- a/init.rb
+++ b/init.rb
@@ -13,8 +13,8 @@ p = Redmine::Plugin.register :redmine_message_customize do
   author_url 'https://github.com/farend'
   settings default: { custom_messages: {} }
   menu :admin_menu, :custom_messages, { controller: 'custom_message_settings', action: 'edit' },
-         caption: :label_custom_messages, html: { class: 'icon icon-edit' }
-  requires_redmine version_or_higher: '3.2'
+         caption: :label_custom_messages, html: { class: 'icon icon-edit' }, icon: 'edit'
+  requires_redmine version_or_higher: '6.0'
 end
 
 Rails.application.config.i18n.load_path += Dir.glob(File.join(p.directory, 'config', 'locales', 'custom_messages', '*.rb'))


### PR DESCRIPTION
This pull request will change all icons in the plugin to support Redmine 6 or later svg icons.
Redmine version supported by this plugin is 6.0

||before |after|
|---|---|---|
|normal mode|<img width="756" alt="screenshot 2024-11-18 15 44 26" src="https://github.com/user-attachments/assets/a618cd8f-32ed-4638-b14c-e6b8a7e1e06c">|<img width="756" alt="screenshot 2024-11-18 15 44 16" src="https://github.com/user-attachments/assets/85784a78-4ea9-4451-92aa-af318fdf64db">|
|yaml mode|<img width="756" alt="screenshot 2024-11-18 15 44 30" src="https://github.com/user-attachments/assets/011d17cd-9341-43a8-9870-a4882e8d5ee5">|<img width="756" alt="screenshot 2024-11-18 15 44 12" src="https://github.com/user-attachments/assets/b576dffc-0e79-4183-a7db-e43ca8e38592">|
