### PR TITLE
Update test targets to the latest 

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,9 @@ name: Test
 
 on:
   push:
+    branches:
+      - 'master'
+      - 'dev*'
   pull_request:
   schedule:
     - cron: "0 23 * * 0-4"   # 08:00 JST, Monday to Friday

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,14 @@ jobs:
             ruby-version: '3.4'
 
     steps:
-    - uses: hidakatsuya/action-setup-redmine@v1
+    - uses: hidakatsuya/action-setup-redmine@0147e23d3e5516edf2a0d2cca095570283ca81b4 # v2.0.0
       with:
         repository: ${{ matrix.redmine-repository }}
         version: ${{ matrix.redmine-version }}
         ruby-version: ${{ matrix.ruby-version }}
         database: 'postgres:14'
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
       with:
         path: plugins/redmine_message_customize
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,6 +3,8 @@ name: Test
 on:
   push:
   pull_request:
+  schedule:
+    - cron: "0 23 * * 0-4"   # 08:00 JST, Monday to Friday
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,11 +12,11 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'master'
-            ruby-version: '3.3'
+            redmine-version: 'stable-3.2'
+            ruby-version: '3.4'
           - redmine-repository: 'redmine/redmine'
             redmine-version: 'master'
-            ruby-version: '3.3'
+            ruby-version: '3.4'
 
     steps:
     - uses: hidakatsuya/action-setup-redmine@v1


### PR DESCRIPTION
This PR updates test targets to the latest and addresses the followings:

* Add scheduled trigger to run tests regularly
* Update actions to the latest and pin to specific commit SHAs
* Prevent duplicate test runs when creating a PR from a branch in this repository