### PR TITLE
Update RedMica test target

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,14 +24,14 @@ jobs:
             ruby-version: '3.4'
 
     steps:
-    - uses: hidakatsuya/action-setup-redmine@0147e23d3e5516edf2a0d2cca095570283ca81b4 # v2.0.0
+    - uses: hidakatsuya/action-setup-redmine@v3.0.1
       with:
         repository: ${{ matrix.redmine-repository }}
         version: ${{ matrix.redmine-version }}
         ruby-version: ${{ matrix.ruby-version }}
         database: 'postgres:14'
 
-    - uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+    - uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1
       with:
         path: plugins/redmine_message_customize
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
       matrix:
         include:
           - redmine-repository: 'redmica/redmica'
-            redmine-version: 'stable-3.2'
+            redmine-version: 'stable-4.0'
             ruby-version: '3.4'
           - redmine-repository: 'redmine/redmine'
             redmine-version: 'master'


### PR DESCRIPTION
This PR changes the RedMica test target from stable-3.2 to stable-4.0 and updates actions.